### PR TITLE
Support absolute paths to source code

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29294,11 +29294,13 @@ function dockerBuildpackCompile({ workingDir, sources, platform, targetVersion }
         else {
             (0, core_1.warning)(`Output directory ${destDir} already exists. Compile will overwrite firmware.bin if it exists.`);
         }
+        (0, core_1.info)(`Compiling...`);
+        const inputDir = sources.charAt(0) === '/' ? sources : `${workingDir}/${sources}`;
         const args = [
             'run',
             '--rm',
             '-v',
-            `${workingDir}/${sources}:/input`,
+            `${inputDir}:/input`,
             '-v',
             `${workingDir}/${destDir}:/output`,
             '-e',

--- a/dist/index.js
+++ b/dist/index.js
@@ -29250,6 +29250,7 @@ const core_1 = __nccwpck_require__(2186);
 const fs_1 = __nccwpck_require__(7147);
 const execa_1 = __importDefault(__nccwpck_require__(5447));
 const util_1 = __nccwpck_require__(2629);
+const path_1 = __importDefault(__nccwpck_require__(1017));
 function dockerCheck() {
     return __awaiter(this, void 0, void 0, function* () {
         let dockerVersion;
@@ -29295,7 +29296,7 @@ function dockerBuildpackCompile({ workingDir, sources, platform, targetVersion }
             (0, core_1.warning)(`Output directory ${destDir} already exists. Compile will overwrite firmware.bin if it exists.`);
         }
         (0, core_1.info)(`Compiling...`);
-        const inputDir = sources.charAt(0) === '/' ? sources : `${workingDir}/${sources}`;
+        const inputDir = path_1.default.isAbsolute(sources) ? sources : path_1.default.join(workingDir, sources);
         const args = [
             'run',
             '--rm',

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -1,5 +1,6 @@
 import { dockerBuildpackCompile, dockerCheck } from './docker';
 import fs from 'fs';
+import { normalize } from 'path';
 
 const execa = require('execa');
 jest.mock('execa');
@@ -118,9 +119,11 @@ describe('dockerBuildpackCompile', () => {
 	});
 
 	it('should mount source code from a relative path with a parent directory', async () => {
+		const workingDir = 'workingDir';
+		const sources = '../../src';
 		const path = await dockerBuildpackCompile({
-			workingDir : 'workingDir',
-			sources : '../../src',
+			workingDir,
+			sources,
 			platform : 'argon',
 			targetVersion : 'latest'
 		});
@@ -131,7 +134,7 @@ describe('dockerBuildpackCompile', () => {
 				'run',
 				'--rm',
 				'-v',
-				'workingDir/../../src:/input',
+				`${normalize(`${workingDir}/${sources}`)}:/input`,
 				'-v',
 				'workingDir/output:/output',
 				'-e',

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -92,4 +92,77 @@ describe('dockerBuildpackCompile', () => {
 			]]);
 		expect(path).toBe('output/firmware.bin');
 	});
+
+	it('should mount source code from a relative path', async () => {
+		const path = await dockerBuildpackCompile({
+			workingDir : 'workingDir',
+			sources : 'src',
+			platform : 'argon',
+			targetVersion : 'latest'
+		});
+		expect(execa).toHaveBeenCalledTimes(2);
+		expect(execa.mock.calls[1]).toEqual([
+			'docker',
+			[
+				'run',
+				'--rm',
+				'-v',
+				'workingDir/src:/input',
+				'-v',
+				'workingDir/output:/output',
+				'-e',
+				'PLATFORM_ID=12',
+				'particle/buildpack-particle-firmware:4.0.2-argon'
+			]]);
+		expect(path).toBe('output/firmware.bin');
+	});
+
+	it('should mount source code from a relative path with a parent directory', async () => {
+		const path = await dockerBuildpackCompile({
+			workingDir : 'workingDir',
+			sources : '../../src',
+			platform : 'argon',
+			targetVersion : 'latest'
+		});
+		expect(execa).toHaveBeenCalledTimes(2);
+		expect(execa.mock.calls[1]).toEqual([
+			'docker',
+			[
+				'run',
+				'--rm',
+				'-v',
+				'workingDir/../../src:/input',
+				'-v',
+				'workingDir/output:/output',
+				'-e',
+				'PLATFORM_ID=12',
+				'particle/buildpack-particle-firmware:4.0.2-argon'
+			]]);
+		expect(path).toBe('output/firmware.bin');
+	});
+
+	it('should mount source code from an absolute path', async () => {
+		const path = await dockerBuildpackCompile({
+			workingDir : 'workingDir',
+			sources : '/absolute/path/to/src',
+			platform : 'argon',
+			targetVersion : 'latest'
+		});
+		expect(execa).toHaveBeenCalledTimes(2);
+		expect(execa.mock.calls[1]).toEqual([
+			'docker',
+			[
+				'run',
+				'--rm',
+				'-v',
+				'/absolute/path/to/src:/input',
+				'-v',
+				'workingDir/output:/output',
+				'-e',
+				'PLATFORM_ID=12',
+				'particle/buildpack-particle-firmware:4.0.2-argon'
+			]]);
+		expect(path).toBe('output/firmware.bin');
+	});
+
 });

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -57,11 +57,13 @@ export async function dockerBuildpackCompile(
 		warning(`Output directory ${destDir} already exists. Compile will overwrite firmware.bin if it exists.`);
 	}
 
+	info(`Compiling...`);
+	const inputDir = sources.charAt(0) === '/' ? sources : `${workingDir}/${sources}`;
 	const args = [
 		'run',
 		'--rm',
 		'-v',
-		`${workingDir}/${sources}:/input`,
+		`${inputDir}:/input`,
 		'-v',
 		`${workingDir}/${destDir}:/output`,
 		'-e',

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,7 +1,8 @@
-import 	{ info, warning } from '@actions/core';
+import { info, warning } from '@actions/core';
 import { existsSync, mkdirSync } from 'fs';
 import execa from 'execa';
 import { getPlatformId } from './util';
+import path from 'path';
 
 export async function dockerCheck(): Promise<boolean> {
 	let dockerVersion;
@@ -58,7 +59,7 @@ export async function dockerBuildpackCompile(
 	}
 
 	info(`Compiling...`);
-	const inputDir = sources.charAt(0) === '/' ? sources : `${workingDir}/${sources}`;
+	const inputDir = path.isAbsolute(sources) ? sources : path.join(workingDir, sources);
 	const args = [
 		'run',
 		'--rm',


### PR DESCRIPTION
Relative paths inside the action are more common, but it should work for absolute paths also.