### PR TITLE
feat: [sc-117417] Add semver support and device-os-output variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ A GitHub Action to compile Particle application firmware
       
     # Target Device OS firmware version
     # Allowed values:
-    #   * latest:     the most recent Device OS version for the platform
-    #   * latest-lts: the most recent LTS Device OS version for the platform
-    #   * <version>:  a specific Device OS version, e.g. 2.3.1
-    #   * ^<version>: a semver range, e.g. ^5.3.0
+    #   latest:     the most recent Device OS version for the platform
+    #   latest-lts: the most recent LTS Device OS version for the platform
+    #   <version>:  a specific Device OS version, e.g. 2.3.1
+    #   ^<version>: a semver range, e.g. ^5.3.0
     # For production projects, you should pin to a specific Device OS semver range, e.g. ^4.0.0
     # Required: false
     device-os-version: 'latest-lts'
@@ -36,7 +36,7 @@ A GitHub Action to compile Particle application firmware
 ### Outputs
 
 * `artifact-path`: Path to the compiled binary artifact. Typically, it will be `output/firmware.bin`
-* `device-os-version`: The Device OS version that was used for compilation. This may differ from the requested version if the requested version is a semver range or `latest` or `latest-lts`.
+* `device-os-version`: The Device OS version that was used for compilation. This may differ from the requested version if the requested version is a semver range or `latest` or `latest-lts`. Example: `2.3.1`
 
 ### Example Pipeline
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,25 @@ A GitHub Action to compile Particle application firmware
     sources-folder: 'src'
       
     # Target Device OS firmware version
-    # For production projects, you should pin to a specific Device OS version
+    # Allowed values:
+    #   * latest:     the most recent Device OS version for the platform
+    #   * latest-lts: the most recent LTS Device OS version for the platform
+    #   * <version>:  a specific Device OS version, e.g. 2.3.1
+    #   * ^<version>: a semver range, e.g. ^5.3.0
+    # For production projects, you should pin to a specific Device OS semver range, e.g. ^4.0.0
     # Required: false
-    device-os-version: 'latest'
+    device-os-version: 'latest-lts'
       
     # Particle access token
     # If provided, the action will use the Particle Cloud Compiler instead of compiling within the GitHub Action runner
     # Required: false
     particle-access-token: ''
 ```
+
+### Outputs
+
+* `artifact-path`: Path to the compiled binary artifact. Typically, it will be `output/firmware.bin`
+* `device-os-version`: The Device OS version that was used for compilation. This may differ from the requested version if the requested version is a semver range or `latest` or `latest-lts`.
 
 ### Example Pipeline
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A GitHub Action to compile Particle application firmware
     #   latest-lts: the most recent LTS Device OS version for the platform
     #   <version>:  a specific Device OS version, e.g. 2.3.1
     #   ^<version>: a semver range, e.g. ^5.3.0
-    # For production projects, you should pin to a specific Device OS semver range, e.g. ^4.0.0
+    # For production projects, you should pin to a specific Device OS version or semver range, e.g. ^4.0.0
     # Required: false
     device-os-version: 'latest-lts'
       

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,8 @@ inputs:
 outputs:
   artifact-path:
     description: 'Path to the compiled binary file. Example: output/firmware.bin'
+  device-os-version:
+    description: 'When inputs.device-os-version=latest, this output contains the actual Device OS version used for compilation. Example: 4.0.2'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     default: ''
   device-os-version:
     required: false
-    description: 'Target Device OS firmware version. Example: 4.0.2'
+    description: 'Target Device OS firmware version. Allowed values: latest, latest-lts, or a semver version number. Example: latest, latest-lts, 4.x, ^5.3.0, 1.4.4'
     default: 'latest'
   sources-folder:
     required: false
@@ -21,7 +21,7 @@ outputs:
   artifact-path:
     description: 'Path to the compiled binary file. Example: output/firmware.bin'
   device-os-version:
-    description: 'When inputs.device-os-version=latest, this output contains the actual Device OS version used for compilation. Example: 4.0.2'
+    description: 'This output contains the actual Device OS version used for compilation. Example: 4.0.2'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   device-os-version:
     required: false
     description: 'Target Device OS firmware version. Allowed values: latest, latest-lts, or a semver version number. Example: latest, latest-lts, 4.x, ^5.3.0, 1.4.4'
-    default: 'latest'
+    default: 'latest-lts'
   sources-folder:
     required: false
     description: 'Path to directory with sources to compile. Example: src'

--- a/dist/index.js
+++ b/dist/index.js
@@ -29257,7 +29257,6 @@ function compileAction() {
             (0, util_1.validatePlatformName)(platform);
             const targetVersion = yield (0, util_1.resolveVersion)(platform, version);
             yield (0, util_1.validatePlatformDeviceOsTarget)(platform, targetVersion);
-            (0, core_1.info)(`Targeting '${targetVersion}' Device OS version for platform '${platform}'`);
             let outputPath;
             if (!auth) {
                 (0, core_1.info)('No access token provided, running local compilation');
@@ -29335,9 +29334,7 @@ function dockerBuildpackCompile({ workingDir, sources, platform, targetVersion }
     return __awaiter(this, void 0, void 0, function* () {
         // Note: the buildpack only detects *.c and *.cpp files
         // https://github.com/particle-iot/device-os/blob/196d497dd4c16ab83db6ea610cf2433047226a6a/user/build.mk#L64-L65
-        const platformId = (0, util_1.getPlatformId)(platform);
-        (0, core_1.info)(`Fetching docker buildpack for platform '${platform}' and target '${targetVersion}'`);
-        (0, core_1.info)(`This can take a minute....`);
+        (0, core_1.info)(`Fetching docker buildpack. This can take a minute...`);
         const dockerPull = yield (0, execa_1.default)('docker', [
             'pull',
             `particle/buildpack-particle-firmware:${targetVersion}-${platform}`
@@ -29353,8 +29350,9 @@ function dockerBuildpackCompile({ workingDir, sources, platform, targetVersion }
         else {
             (0, core_1.warning)(`Output directory ${destDir} already exists. Compile will overwrite firmware.bin if it exists.`);
         }
-        (0, core_1.info)(`Compiling...`);
+        (0, core_1.info)(`Compiling code in '${sources}' for platform '${platform}' with target version '${targetVersion}'`);
         const inputDir = path_1.default.isAbsolute(sources) ? sources : path_1.default.join(workingDir, sources);
+        const platformId = (0, util_1.getPlatformId)(platform);
         const args = [
             'run',
             '--rm',
@@ -29400,17 +29398,16 @@ const ParticleApi = __nccwpck_require__(2918);
 const particle = new ParticleApi();
 function particleCloudCompile({ sources, platform, auth, targetVersion }) {
     return __awaiter(this, void 0, void 0, function* () {
-        (0, core_1.info)(`Compiling code in ${sources}`);
+        (0, core_1.info)(`Compiling code in '${sources}' for platform '${platform}' with target version '${targetVersion}'`);
         if (!sources) {
             throw new Error('No source code sources specified');
         }
         if (sources === './' || sources === '.') {
             sources = process.cwd();
         }
-        const platformId = (0, util_1.getPlatformId)(platform);
         const files = (0, util_1.getCode)(sources);
-        (0, core_1.info)(`Compiling code for platform '${platform}' with target version '${targetVersion}'`);
         (0, core_1.info)(`Files: ${JSON.stringify(Object.keys(files))}`);
+        const platformId = (0, util_1.getPlatformId)(platform);
         let binaryId = '';
         try {
             const resp = yield particle.compileCode({

--- a/dist/index.js
+++ b/dist/index.js
@@ -29246,6 +29246,7 @@ exports.compileAction = void 0;
 const core_1 = __nccwpck_require__(2186);
 const docker_1 = __nccwpck_require__(6512);
 const particle_api_1 = __nccwpck_require__(6032);
+const util_1 = __nccwpck_require__(2629);
 function compileAction() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -29269,6 +29270,8 @@ function compileAction() {
             }
             if (outputPath) {
                 (0, core_1.setOutput)('artifact-path', outputPath);
+                const version = targetVersion === 'latest' ? yield (0, util_1.getLatestFirmwareVersion)(platform) : targetVersion;
+                (0, core_1.setOutput)('device-os-version', version);
             }
             else {
                 (0, core_1.setFailed)(`Failed to compile code in '${sources}'`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -29270,7 +29270,7 @@ function compileAction() {
             }
             if (outputPath) {
                 (0, core_1.setOutput)('artifact-path', outputPath);
-                const version = targetVersion === 'latest' ? yield (0, util_1.getLatestFirmwareVersion)(platform) : targetVersion;
+                const version = targetVersion === 'latest' || !targetVersion ? yield (0, util_1.getLatestFirmwareVersion)(platform) : targetVersion;
                 (0, core_1.setOutput)('device-os-version', version);
             }
             else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@particle/device-constants": "^3.1.7",
         "execa": "^5.0.0",
         "glob": "^7.2.3",
-        "particle-api-js": "^9.4.1"
+        "particle-api-js": "^9.4.1",
+        "semver": "^7.3.8"
       },
       "devDependencies": {
         "@types/jest": "^27.5.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "@particle/device-constants": "^3.1.7",
     "execa": "^5.0.0",
     "glob": "^7.2.3",
-    "particle-api-js": "^9.4.1"
+    "particle-api-js": "^9.4.1",
+    "semver": "^7.3.8"
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -9,7 +9,8 @@ describe('compileAction', () => {
 		const dockerBuildpackCompileMock = jest.fn();
 		jest.mock('./util', () => ({
 			resolveVersion: jest.fn(),
-			validatePlatformFirmware: jest.fn()
+			validatePlatformName: jest.fn(),
+			validatePlatformDeviceOsTarget: jest.fn()
 		}));
 		jest.mock('./docker', () => ({
 			dockerCheck: dockerCheckMock,
@@ -24,7 +25,8 @@ describe('compileAction', () => {
 	it('should use compile in the cloud if access token is provided', async () => {
 		jest.mock('./util', () => ({
 			resolveVersion: jest.fn(),
-			validatePlatformFirmware: jest.fn()
+			validatePlatformName: jest.fn(),
+			validatePlatformDeviceOsTarget: jest.fn()
 		}));
 		// mock particle-access-token input
 		jest.mock('@actions/core', () => ({

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -1,3 +1,5 @@
+import nock from 'nock';
+
 describe('compileAction', () => {
 
 	afterEach(() => {
@@ -67,4 +69,109 @@ describe('compileAction', () => {
 		expect(setFailedMock).toHaveBeenCalled();
 		expect(setFailedMock).toHaveBeenCalledWith('Failed to compile code in cloud');
 	});
+
+	it('should have the same device-os-version output as input when it is a known version', async () => {
+		const setOutputMock = jest.fn();
+		const setFailedMock = jest.fn();
+		const knownVersion = '2.3.1';
+		jest.mock('@actions/core', () => ({
+			getInput: jest.fn().mockImplementation((name: string) => {
+				if (name === 'particle-platform-name') {
+					return 'electron';
+				}
+				if (name === 'device-os-version') {
+					return knownVersion;
+				}
+				return '';
+			}),
+			setFailed: setFailedMock,
+			info: jest.fn(),
+			setOutput: setOutputMock
+		}));
+
+		const dockerBuildpackCompileMock = jest.fn().mockResolvedValue('test-path');
+		jest.mock('./docker', () => ({
+			dockerCheck: jest.fn(),
+			dockerBuildpackCompile: dockerBuildpackCompileMock
+		}));
+		const { compileAction } = await import('./action');
+		await compileAction();
+		expect(setOutputMock).toHaveBeenNthCalledWith(1, 'artifact-path', 'test-path');
+		expect(setOutputMock).toHaveBeenNthCalledWith(2, 'device-os-version', knownVersion);
+		expect(setFailedMock).not.toHaveBeenCalled();
+	});
+
+	it('should set the device-os-version output to an actual version when latest is the input', async () => {
+		nock('https://binaries.particle.io')
+			.get('/firmware-versions-manifest.json')
+			.once()
+			.replyWithFile(200, `test/fixtures/firmware-manifest-v1/manifest.json`);
+
+		const setOutputMock = jest.fn();
+		const setFailedMock = jest.fn();
+		jest.mock('@actions/core', () => ({
+			getInput: jest.fn().mockImplementation((name: string) => {
+				if (name === 'particle-platform-name') {
+					return 'argon';
+				}
+				if (name === 'device-os-version') {
+					return 'latest';
+				}
+				return '';
+			}),
+			setFailed: setFailedMock,
+			info: jest.fn(),
+			setOutput: setOutputMock
+		}));
+
+		const dockerBuildpackCompileMock = jest.fn().mockResolvedValue('test-path');
+		jest.mock('./docker', () => ({
+			dockerCheck: jest.fn(),
+			dockerBuildpackCompile: dockerBuildpackCompileMock
+		}));
+		const { compileAction } = await import('./action');
+		await compileAction();
+		expect(setOutputMock).toHaveBeenNthCalledWith(1, 'artifact-path', 'test-path');
+		expect(setOutputMock).toHaveBeenNthCalledWith(2, 'device-os-version', '4.0.2');
+		expect(setFailedMock).not.toHaveBeenCalled();
+		expect(nock.pendingMocks()).toEqual([]);
+	});
+
+	it('should set the device-os-version output to an actual version when input version is empty', async () => {
+		nock('https://binaries.particle.io')
+			.get('/firmware-versions-manifest.json')
+			.once()
+			.replyWithFile(200, `test/fixtures/firmware-manifest-v1/manifest.json`);
+
+		const setOutputMock = jest.fn();
+		const setFailedMock = jest.fn();
+		jest.mock('@actions/core', () => ({
+			getInput: jest.fn().mockImplementation((name: string) => {
+				if (name === 'particle-platform-name') {
+					return 'argon';
+				}
+				if (name === 'device-os-version') {
+					return '';
+				}
+				return '';
+			}),
+			setFailed: setFailedMock,
+			info: jest.fn(),
+			setOutput: setOutputMock
+		}));
+
+		const dockerBuildpackCompileMock = jest.fn().mockResolvedValue('test-path');
+		jest.mock('./docker', () => ({
+			dockerCheck: jest.fn(),
+			dockerBuildpackCompile: dockerBuildpackCompileMock
+		}));
+		const { compileAction } = await import('./action');
+		await compileAction();
+		expect(setOutputMock).toHaveBeenNthCalledWith(1, 'artifact-path', 'test-path');
+		expect(setOutputMock).toHaveBeenNthCalledWith(2, 'device-os-version', '4.0.2');
+		expect(setFailedMock).not.toHaveBeenCalled();
+		expect(nock.pendingMocks()).toEqual([]);
+	});
+
+
 });

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,7 +1,7 @@
 import { getInput, info, setFailed, setOutput } from '@actions/core';
 import { dockerBuildpackCompile, dockerCheck } from './docker';
 import { particleCloudCompile, particleDownloadBinary } from './particle-api';
-import { resolveVersion, validatePlatformFirmware } from './util';
+import { resolveVersion, validatePlatformDeviceOsTarget, validatePlatformName } from './util';
 
 export async function compileAction(): Promise<void> {
 	try {
@@ -10,8 +10,10 @@ export async function compileAction(): Promise<void> {
 		const version: string = getInput('device-os-version');
 		const sources: string = getInput('sources-folder');
 
+		validatePlatformName(platform);
+
 		const targetVersion = await resolveVersion(platform, version);
-		await validatePlatformFirmware(platform, targetVersion);
+		await validatePlatformDeviceOsTarget(platform, targetVersion);
 		info(`Targeting '${targetVersion}' Device OS version for platform '${platform}'`);
 
 		let outputPath: string | undefined;

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,6 +1,7 @@
 import { getInput, info, setFailed, setOutput } from '@actions/core';
 import { dockerBuildpackCompile, dockerCheck } from './docker';
 import { particleCloudCompile, particleDownloadBinary } from './particle-api';
+import { getLatestFirmwareVersion } from './util';
 
 export async function compileAction(): Promise<void> {
 	try {
@@ -25,6 +26,8 @@ export async function compileAction(): Promise<void> {
 
 		if (outputPath) {
 			setOutput('artifact-path', outputPath);
+			const version = targetVersion === 'latest' || !targetVersion ? await getLatestFirmwareVersion(platform) : targetVersion;
+			setOutput('device-os-version', version);
 		} else {
 			setFailed(`Failed to compile code in '${sources}'`);
 		}

--- a/src/action.ts
+++ b/src/action.ts
@@ -14,7 +14,6 @@ export async function compileAction(): Promise<void> {
 
 		const targetVersion = await resolveVersion(platform, version);
 		await validatePlatformDeviceOsTarget(platform, targetVersion);
-		info(`Targeting '${targetVersion}' Device OS version for platform '${platform}'`);
 
 		let outputPath: string | undefined;
 		if (!auth) {

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -1,6 +1,7 @@
 import { dockerBuildpackCompile, dockerCheck } from './docker';
 import fs from 'fs';
 import { normalize } from 'path';
+import nock from "nock";
 
 const execa = require('execa');
 jest.mock('execa');
@@ -56,6 +57,12 @@ describe('dockerCheck', () => {
 });
 
 describe('dockerBuildpackCompile', () => {
+	beforeEach(() => {
+		nock('https://binaries.particle.io')
+			.get('/firmware-versions-manifest.json')
+			.replyWithFile(200, `test/fixtures/firmware-manifest-v1/manifest.json`);
+	});
+
 	it('should throw on invalid platform', () => {
 		return expect(dockerBuildpackCompile({
 			workingDir: 'workingDir',

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -77,7 +77,7 @@ describe('dockerBuildpackCompile', () => {
 			workingDir: 'workingDir',
 			sources: 'sources',
 			platform: 'argon',
-			targetVersion: 'latest'
+			targetVersion: '4.0.2'
 		});
 		expect(execa).toHaveBeenCalledTimes(2);
 		expect(execa.mock.calls[0]).toEqual([
@@ -108,7 +108,7 @@ describe('dockerBuildpackCompile', () => {
 			workingDir: 'workingDir',
 			sources: 'src',
 			platform: 'argon',
-			targetVersion: 'latest'
+			targetVersion: '4.0.2'
 		});
 		expect(execa).toHaveBeenCalledTimes(2);
 		expect(execa.mock.calls[1]).toEqual([
@@ -134,7 +134,7 @@ describe('dockerBuildpackCompile', () => {
 			workingDir,
 			sources,
 			platform: 'argon',
-			targetVersion: 'latest'
+			targetVersion: '4.0.2'
 		});
 		expect(execa).toHaveBeenCalledTimes(2);
 		expect(execa.mock.calls[1]).toEqual([
@@ -158,7 +158,7 @@ describe('dockerBuildpackCompile', () => {
 			workingDir: 'workingDir',
 			sources: '/absolute/path/to/src',
 			platform: 'argon',
-			targetVersion: 'latest'
+			targetVersion: '4.0.2'
 		});
 		expect(execa).toHaveBeenCalledTimes(2);
 		expect(execa.mock.calls[1]).toEqual([

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -1,7 +1,7 @@
 import { dockerBuildpackCompile, dockerCheck } from './docker';
 import fs from 'fs';
 import { normalize } from 'path';
-import nock from "nock";
+import nock from 'nock';
 
 const execa = require('execa');
 jest.mock('execa');

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,7 +1,7 @@
 import { info, warning } from '@actions/core';
 import { existsSync, mkdirSync } from 'fs';
 import execa from 'execa';
-import { getLatestFirmwareVersion, getPlatformId, validatePlatformFirmware } from './util';
+import { getPlatformId } from './util';
 import path from 'path';
 
 export async function dockerCheck(): Promise<boolean> {
@@ -30,12 +30,6 @@ export async function dockerBuildpackCompile(
 	// https://github.com/particle-iot/device-os/blob/196d497dd4c16ab83db6ea610cf2433047226a6a/user/build.mk#L64-L65
 
 	const platformId = getPlatformId(platform);
-
-	if (targetVersion === 'latest' || !targetVersion) {
-		targetVersion = await getLatestFirmwareVersion(platform);
-		info(`No device os version specified, using '${targetVersion}' as latest version for platform '${platform}'`);
-	}
-	await validatePlatformFirmware(platform, targetVersion);
 
 	info(`Fetching docker buildpack for platform '${platform}' and target '${targetVersion}'`);
 	info(`This can take a minute....`);

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -29,10 +29,7 @@ export async function dockerBuildpackCompile(
 	// Note: the buildpack only detects *.c and *.cpp files
 	// https://github.com/particle-iot/device-os/blob/196d497dd4c16ab83db6ea610cf2433047226a6a/user/build.mk#L64-L65
 
-	const platformId = getPlatformId(platform);
-
-	info(`Fetching docker buildpack for platform '${platform}' and target '${targetVersion}'`);
-	info(`This can take a minute....`);
+	info(`Fetching docker buildpack. This can take a minute...`);
 	const dockerPull = await execa('docker', [
 		'pull',
 		`particle/buildpack-particle-firmware:${targetVersion}-${platform}`
@@ -50,8 +47,9 @@ export async function dockerBuildpackCompile(
 		warning(`Output directory ${destDir} already exists. Compile will overwrite firmware.bin if it exists.`);
 	}
 
-	info(`Compiling...`);
+	info(`Compiling code in '${sources}' for platform '${platform}' with target version '${targetVersion}'`);
 	const inputDir = path.isAbsolute(sources) ? sources : path.join(workingDir, sources);
+	const platformId = getPlatformId(platform);
 	const args = [
 		'run',
 		'--rm',

--- a/src/particle-api.test.ts
+++ b/src/particle-api.test.ts
@@ -62,7 +62,8 @@ describe('particleCloudCompile', () => {
 			await particleCloudCompile({
 				sources: '',
 				platform: 'core',
-				auth: 'token'
+				auth: 'token',
+				targetVersion: '1.4.4'
 			});
 		}).rejects.toThrow('No source code sources specified');
 	});
@@ -72,7 +73,8 @@ describe('particleCloudCompile', () => {
 			await particleCloudCompile({
 				sources: './fake-src-sources',
 				platform: 'core',
-				auth: 'token'
+				auth: 'token',
+				targetVersion: '1.4.4'
 			});
 		}).rejects.toThrow('Source code ./fake-src-sources does not exist');
 	});
@@ -93,7 +95,8 @@ describe('particleCloudCompile', () => {
 			await particleCloudCompile({
 				sources: emptySrcDir,
 				platform: 'core',
-				auth: 'token'
+				auth: 'token',
+				targetVersion: '1.4.4'
 			});
 		}).rejects.toThrow(`There are no valid source code files included in ${emptySrcDir}`);
 	});
@@ -115,7 +118,8 @@ describe('particleCloudCompile', () => {
 			await particleCloudCompile({
 				sources: emptySrcDir,
 				platform: 'core',
-				auth: 'token'
+				auth: 'token',
+				targetVersion: '1.4.4'
 			});
 		}).rejects.toThrow(`There are no valid source code files included in ${emptySrcDir}`);
 
@@ -138,7 +142,8 @@ describe('particleCloudCompile', () => {
 			await particleCloudCompile({
 				sources: emptySrcDir,
 				platform: 'core',
-				auth: 'token'
+				auth: 'token',
+				targetVersion: '1.4.4'
 			});
 		}).rejects.toThrow(`There are no valid source code files included in ${emptySrcDir}`);
 
@@ -150,7 +155,7 @@ describe('particleCloudCompile', () => {
 			sources: '.',
 			platform: 'core',
 			auth: 'token',
-			targetVersion: 'latest'
+			targetVersion: '1.4.4'
 		});
 		expect(mockCompileCode).toHaveBeenCalledTimes(1);
 		expect(mockCompileCode).toHaveBeenCalledWith({
@@ -170,7 +175,7 @@ describe('particleCloudCompile', () => {
 			sources: './',
 			platform: 'argon',
 			auth: 'token',
-			targetVersion: 'latest'
+			targetVersion: '4.0.2'
 		});
 		expect(mockCompileCode).toHaveBeenCalledTimes(1);
 		expect(mockCompileCode).toHaveBeenCalledWith({
@@ -189,7 +194,7 @@ describe('particleCloudCompile', () => {
 			sources: 'test/fixtures/single-file-firmware',
 			platform: 'electron',
 			auth: 'token',
-			targetVersion: 'latest'
+			targetVersion: '2.3.1'
 		});
 		expect(mockCompileCode).toHaveBeenCalledTimes(1);
 		expect(mockCompileCode).toHaveBeenCalledWith({
@@ -207,7 +212,8 @@ describe('particleCloudCompile', () => {
 		const result = await particleCloudCompile({
 			sources: 'test/fixtures/single-file-firmware',
 			platform: 'core',
-			auth: 'token'
+			auth: 'token',
+			targetVersion: 'latest-lts'
 		});
 		expect(mockCompileCode).toHaveBeenCalledTimes(1);
 		expect(result).toEqual('abc123');
@@ -229,7 +235,8 @@ describe('particleCloudCompile', () => {
 		const result = await particleCloudCompile({
 			sources: 'test/fixtures/single-file-firmware',
 			platform: 'core',
-			auth: 'token'
+			auth: 'token',
+			targetVersion: 'latest'
 		});
 		expect(mockCompileCode).toHaveBeenCalledTimes(1);
 		expect(result).toEqual('');
@@ -247,7 +254,8 @@ describe('particleCloudCompile', () => {
 			await particleCloudCompile({
 				sources: 'test/fixtures/single-file-firmware',
 				platform: 'core',
-				auth: 'token'
+				auth: 'token',
+				targetVersion: 'latest'
 			});
 		}).rejects.toThrow(`Error: unknown response from Particle Cloud: {"body":{"ok":false}}`);
 
@@ -261,7 +269,7 @@ describe('particleCloudCompile', () => {
 			sources: `${cwd}/test/fixtures/single-file-firmware`,
 			platform: 'electron',
 			auth: 'token',
-			targetVersion: 'latest'
+			targetVersion: '2.3.1'
 		});
 		expect(mockCompileCode).toHaveBeenCalledTimes(1);
 		expect(mockCompileCode).toHaveBeenCalledWith({

--- a/src/particle-api.test.ts
+++ b/src/particle-api.test.ts
@@ -2,6 +2,7 @@ import { sep } from 'node:path';
 import { mkdtemp } from 'node:fs';
 import { tmpdir } from 'os';
 import { readFileSync, writeFileSync } from 'fs';
+import nock from 'nock';
 
 // Need to be before imports
 const mockCompileCode = jest.fn().mockImplementation(() => {
@@ -45,6 +46,12 @@ afterEach(() => {
 
 describe('particleCloudCompile', () => {
 	const originalDir = process.cwd();
+
+	beforeEach(() => {
+		nock('https://binaries.particle.io')
+			.get('/firmware-versions-manifest.json')
+			.replyWithFile(200, `test/fixtures/firmware-manifest-v1/manifest.json`);
+	});
 
 	afterEach(() => {
 		process.chdir(originalDir);

--- a/src/particle-api.ts
+++ b/src/particle-api.ts
@@ -16,7 +16,7 @@ interface ParticleCloudCompileParams {
 export async function particleCloudCompile(
 	{ sources, platform, auth, targetVersion }: ParticleCloudCompileParams
 ): Promise<string> {
-	info(`Compiling code in ${sources}`);
+	info(`Compiling code in '${sources}' for platform '${platform}' with target version '${targetVersion}'`);
 	if (!sources) {
 		throw new Error('No source code sources specified');
 	}
@@ -25,13 +25,11 @@ export async function particleCloudCompile(
 		sources = process.cwd();
 	}
 
-	const platformId = getPlatformId(platform);
 
 	const files = getCode(sources);
-
-	info(`Compiling code for platform '${platform}' with target version '${targetVersion}'`);
 	info(`Files: ${JSON.stringify(Object.keys(files))}`);
 
+	const platformId = getPlatformId(platform);
 	let binaryId = '';
 	try {
 		const resp = await particle.compileCode({

--- a/src/particle-api.ts
+++ b/src/particle-api.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line max-len
 import { error, info } from '@actions/core';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
-import { getCode, getLatestFirmwareVersion, getPlatformId, validatePlatformFirmware } from './util';
+import { getCode, getPlatformId } from './util';
 
 const ParticleApi = require('particle-api-js');
 const particle = new ParticleApi();
@@ -10,7 +10,7 @@ interface ParticleCloudCompileParams {
 	sources: string;
 	platform: string;
 	auth: string;
-	targetVersion?: string;
+	targetVersion: string;
 }
 
 export async function particleCloudCompile(
@@ -24,12 +24,6 @@ export async function particleCloudCompile(
 	if (sources === './' || sources === '.') {
 		sources = process.cwd();
 	}
-
-	if (targetVersion === 'latest' || !targetVersion) {
-		targetVersion = await getLatestFirmwareVersion(platform);
-		info(`No device os version specified, using '${targetVersion}' as latest version for platform '${platform}'`);
-	}
-	await validatePlatformFirmware(platform, targetVersion);
 
 	const platformId = getPlatformId(platform);
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -4,7 +4,7 @@ import {
 	getCode,
 	resolveVersion,
 	getPlatformId,
-	validatePlatformFirmware
+	validatePlatformDeviceOsTarget, validatePlatformName
 } from './util';
 import nock from 'nock';
 import { readFileSync } from 'fs';
@@ -131,14 +131,23 @@ describe('fetchFirmwareManifest', () => {
 	});
 });
 
-describe('validatePlatformFirmware', () => {
+describe('validatePlatformName', () => {
+	it('should return true if the platform is valid', () => {
+		expect(validatePlatformName('electron')).toEqual(true);
+	});
+	it('should throw an error if the platform is not valid', () => {
+		expect(() => validatePlatformName('not_a_platform')).toThrow();
+	});
+});
+
+describe('validatePlatformDeviceOsTarget', () => {
 	it('should return true if there is a device os version the supports the target platform', async () => {
 		nock('https://binaries.particle.io')
 			.get('/firmware-versions-manifest.json')
 			.replyWithFile(200, `test/fixtures/firmware-manifest-v1/manifest.json`);
 
-		expect(await validatePlatformFirmware('core', '1.4.4')).toEqual(true);
-		expect(await validatePlatformFirmware('argon', '4.0.2')).toEqual(true);
+		expect(await validatePlatformDeviceOsTarget('core', '1.4.4')).toEqual(true);
+		expect(await validatePlatformDeviceOsTarget('argon', '4.0.2')).toEqual(true);
 	});
 
 	it('should throw if there is not a device os version the supports the target platform', async () => {
@@ -146,8 +155,8 @@ describe('validatePlatformFirmware', () => {
 			.get('/firmware-versions-manifest.json')
 			.replyWithFile(200, `test/fixtures/firmware-manifest-v1/manifest.json`);
 
-		await expect(validatePlatformFirmware('core', '2.3.1')).rejects.toThrow(`Device OS version '2.3.1' does not support platform 'core'`);
-		await expect(validatePlatformFirmware('trackerm', '2.3.1')).rejects.toThrow(`Device OS version '2.3.1' does not support platform 'trackerm'`);
+		await expect(validatePlatformDeviceOsTarget('core', '2.3.1')).rejects.toThrow(`Device OS version '2.3.1' does not support platform 'core'`);
+		await expect(validatePlatformDeviceOsTarget('trackerm', '2.3.1')).rejects.toThrow(`Device OS version '2.3.1' does not support platform 'trackerm'`);
 	});
 
 	it('should throw if the device os version is not valid', async () => {
@@ -155,7 +164,7 @@ describe('validatePlatformFirmware', () => {
 			.get('/firmware-versions-manifest.json')
 			.replyWithFile(200, `test/fixtures/firmware-manifest-v1/manifest.json`);
 
-		await expect(validatePlatformFirmware('core', '0.0.0')).rejects.toThrow(`Device OS version '0.0.0' does not exist`);
+		await expect(validatePlatformDeviceOsTarget('core', '0.0.0')).rejects.toThrow(`Device OS version '0.0.0' does not exist`);
 	});
 });
 
@@ -167,19 +176,19 @@ describe('resolveVersion', () => {
 	});
 
 	it('should return the latest version for each platform', async () => {
-		expect(await resolveVersion('argon', 'latest')).toEqual('4.0.2');
-		expect(await resolveVersion('boron', 'latest')).toEqual('4.0.2');
-		expect(await resolveVersion('esomx', 'latest')).toEqual('4.0.2');
-		expect(await resolveVersion('bsom', 'latest')).toEqual('4.0.2');
-		expect(await resolveVersion('b5som', 'latest')).toEqual('4.0.2');
-		expect(await resolveVersion('tracker', 'latest')).toEqual('4.0.2');
-		expect(await resolveVersion('electron', 'latest')).toEqual('2.3.1');
-		expect(await resolveVersion('photon', 'latest')).toEqual('2.3.1');
+		expect(await resolveVersion('argon', 'latest')).toEqual('5.3.0');
+		expect(await resolveVersion('boron', 'latest')).toEqual('5.3.0');
+		expect(await resolveVersion('esomx', 'latest')).toEqual('5.3.0');
+		expect(await resolveVersion('bsom', 'latest')).toEqual('5.3.0');
+		expect(await resolveVersion('b5som', 'latest')).toEqual('5.3.0');
+		expect(await resolveVersion('tracker', 'latest')).toEqual('5.3.0');
+		expect(await resolveVersion('electron', 'latest')).toEqual('3.3.1');
+		expect(await resolveVersion('photon', 'latest')).toEqual('3.3.1');
 		expect(await resolveVersion('xenon', 'latest')).toEqual('1.5.2');
 		expect(await resolveVersion('xsom', 'latest')).toEqual('1.4.4');
 		expect(await resolveVersion('asom', 'latest')).toEqual('1.4.4');
 		expect(await resolveVersion('core', 'latest')).toEqual('1.4.4');
-		expect(await resolveVersion('p1', 'latest')).toEqual('2.3.1');
+		expect(await resolveVersion('p1', 'latest')).toEqual('3.3.1');
 		expect(await resolveVersion('trackerm', 'latest')).toEqual('5.3.0');
 		expect(await resolveVersion('p2', 'latest')).toEqual('5.3.0');
 	});

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -2,7 +2,7 @@ import {
 	_resetFirmwareManifest,
 	fetchFirmwareManifest,
 	getCode,
-	getLatestFirmwareVersion,
+	resolveVersion,
 	getPlatformId,
 	validatePlatformFirmware
 } from './util';
@@ -131,19 +131,6 @@ describe('fetchFirmwareManifest', () => {
 	});
 });
 
-describe('getLatestFirmwareVersion', () => {
-	it('should return the latest version', async () => {
-		nock('https://binaries.particle.io')
-			.get('/firmware-versions-manifest.json')
-			.replyWithFile(200, `test/fixtures/firmware-manifest-v1/manifest.json`);
-
-		expect(await getLatestFirmwareVersion('core')).toEqual('1.4.4');
-		expect(await getLatestFirmwareVersion('argon')).toEqual('4.0.2');
-		expect(await getLatestFirmwareVersion('p1')).toEqual('2.3.1');
-		expect(await getLatestFirmwareVersion('p2')).toEqual('5.3.0');
-	});
-});
-
 describe('validatePlatformFirmware', () => {
 	it('should return true if there is a device os version the supports the target platform', async () => {
 		nock('https://binaries.particle.io')
@@ -169,5 +156,80 @@ describe('validatePlatformFirmware', () => {
 			.replyWithFile(200, `test/fixtures/firmware-manifest-v1/manifest.json`);
 
 		await expect(validatePlatformFirmware('core', '0.0.0')).rejects.toThrow(`Device OS version '0.0.0' does not exist`);
+	});
+});
+
+describe('resolveVersion', () => {
+	beforeAll(() => {
+		nock('https://binaries.particle.io')
+			.get('/firmware-versions-manifest.json')
+			.replyWithFile(200, `test/fixtures/firmware-manifest-v1/manifest.json`);
+	});
+
+	it('should return the latest version for each platform', async () => {
+		expect(await resolveVersion('argon', 'latest')).toEqual('4.0.2');
+		expect(await resolveVersion('boron', 'latest')).toEqual('4.0.2');
+		expect(await resolveVersion('esomx', 'latest')).toEqual('4.0.2');
+		expect(await resolveVersion('bsom', 'latest')).toEqual('4.0.2');
+		expect(await resolveVersion('b5som', 'latest')).toEqual('4.0.2');
+		expect(await resolveVersion('tracker', 'latest')).toEqual('4.0.2');
+		expect(await resolveVersion('electron', 'latest')).toEqual('2.3.1');
+		expect(await resolveVersion('photon', 'latest')).toEqual('2.3.1');
+		expect(await resolveVersion('xenon', 'latest')).toEqual('1.5.2');
+		expect(await resolveVersion('xsom', 'latest')).toEqual('1.4.4');
+		expect(await resolveVersion('asom', 'latest')).toEqual('1.4.4');
+		expect(await resolveVersion('core', 'latest')).toEqual('1.4.4');
+		expect(await resolveVersion('p1', 'latest')).toEqual('2.3.1');
+		expect(await resolveVersion('trackerm', 'latest')).toEqual('5.3.0');
+		expect(await resolveVersion('p2', 'latest')).toEqual('5.3.0');
+	});
+
+	it('should return the latest LTS version for each platform that has one', async () => {
+		expect(await resolveVersion('argon', 'latest-lts')).toEqual('4.0.2');
+		expect(await resolveVersion('boron', 'latest-lts')).toEqual('4.0.2');
+		expect(await resolveVersion('esomx', 'latest-lts')).toEqual('4.0.2');
+		expect(await resolveVersion('bsom', 'latest-lts')).toEqual('4.0.2');
+		expect(await resolveVersion('b5som', 'latest-lts')).toEqual('4.0.2');
+		expect(await resolveVersion('tracker', 'latest-lts')).toEqual('4.0.2');
+		expect(await resolveVersion('electron', 'latest-lts')).toEqual('2.3.1');
+		expect(await resolveVersion('photon', 'latest-lts')).toEqual('2.3.1');
+		expect(await resolveVersion('p1', 'latest-lts')).toEqual('2.3.1');
+	});
+
+	it('should throw for platforms that do not have an LTS version', async () => {
+		await expect(resolveVersion('xenon', 'latest-lts')).rejects.toThrow(`No latest-lts version found for 'xenon'. The latest supported Device OS version is '1.5.2'`);
+		await expect(resolveVersion('xsom', 'latest-lts')).rejects.toThrow(`No latest-lts version found for 'xsom'. The latest supported Device OS version is '1.4.4'`);
+		await expect(resolveVersion('asom', 'latest-lts')).rejects.toThrow(`No latest-lts version found for 'asom'. The latest supported Device OS version is '1.4.4'`);
+		await expect(resolveVersion('core', 'latest-lts')).rejects.toThrow(`No latest-lts version found for 'core'. The latest supported Device OS version is '1.4.4'`);
+		await expect(resolveVersion('trackerm', 'latest-lts')).rejects.toThrow(`No latest-lts version found for 'trackerm'. The latest supported Device OS version is '5.3.0'`);
+		await expect(resolveVersion('p2', 'latest-lts')).rejects.toThrow(`No latest-lts version found for 'p2'. The latest supported Device OS version is '5.3.0'`);
+	});
+
+	it('should return a fixed version', async () => {
+		expect(await resolveVersion('argon', '2.3.1')).toEqual('2.3.1');
+	});
+
+	it('should return the latest 2.x version', async () => {
+		expect(await resolveVersion('argon', '2.x')).toEqual('2.3.1');
+	});
+
+	it('should return the latest 2.3.x version', async () => {
+		expect(await resolveVersion('argon', '2.3.x')).toEqual('2.3.1');
+	});
+
+	it('should handle tilde versions', async () => {
+		expect(await resolveVersion('argon', '~4.0.0')).toEqual('4.0.2');
+	});
+
+	it('should handle caret versions', async () => {
+		expect(await resolveVersion('argon', '^5.0.0')).toEqual('5.3.0');
+	});
+
+	it('should throw if the version is not valid', async () => {
+		await expect(resolveVersion('argon', '100.0.0')).rejects.toThrow(`No Device OS version satisfies '100.0.0'`);
+	});
+
+	it('should throw if the semver version is not valid', async () => {
+		await expect(resolveVersion('argon', '^100.0.0')).rejects.toThrow(`No Device OS version satisfies '^100.0.0'`);
 	});
 });


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/117417

Adds `device-os-version` output. When users pass a semver or `latest` as the `device-os-version` input, it may be useful to know which Device OS version the firmware was compiled against. 

