### PR TITLE
Add automatic product firmware versioning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,29 @@ jobs:
           particle-access-token: ${{ secrets.PARTICLE_ACCESS_TOKEN }}
           particle-platform-name: 'argon'
           sources-folder: 'test/fixtures/single-file-firmware'
+  test-auto-version:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: 'Verify product version is 100'
+        run: |
+          cat test/fixtures/product-firmware/application.cpp | grep -q 'PRODUCT_VERSION(100);'
+      - uses: ./
+        name: 'Bump product version and compile'
+        with:
+          particle-access-token: ${{ secrets.PARTICLE_ACCESS_TOKEN }}
+          particle-platform-name: 'boron'
+          sources-folder: 'test/fixtures/product-firmware'
+          device-os-version: 'latest-lts'
+          auto-version: 'true'
+      - name: 'Verify product version is 101'
+        run: |
+          cat test/fixtures/product-firmware/application.cpp | grep -q 'PRODUCT_VERSION(101);'
   test-local-compile:
     strategy:
       matrix:

--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -1,3 +1,146 @@
 # Automatic Product Firmware Versioning
 
-todo
+## Overview
+
+The auto-versioning feature is designed to manage product firmware version numbers in an automated and consistent manner.
+
+## Usage
+
+Auto-versioning is disabled by default. To enable auto-versioning:
+
+1. Set the `auto-version` input parameter to `true`.
+2. Add `fetch-depth: 0` to the `actions/checkout` step. This will ensure that the entire git history is available to the action.
+3. [optional] Set the `auto-version-macro-name` input parameter to the name of the macro that contains the product version number. The default value is `PRODUCT_VERSION`.
+
+You may also want to update your GitHub Actions workflow to commit the updated version file to the repository.
+This will ensure that the version number is updated in the repository.
+See the example workflow below for more details.
+
+## How It Works
+
+The auto-versioning feature works by finding the product version macro and the latest version number in code in your `sources-folder`.
+
+If the git revision of the `sources-folder` is newer than the git revision that set the product version, the version number will be incremented.
+
+The auto-versioning feature does not commit the updated version file to the repository. You will need to commit the updated version file to the repository.
+
+## Example Workflow
+
+This example workflow runs on every push to the `main` branch in the specified paths. It:
+
+1. compiles the firmware
+1. increments the version number if the firmware code has changed since the last version
+1. _if the version number was incremented, the workflow continues, otherwise it skips the remaining steps_
+1. commits the updated version file to the repository
+1. pushes the changes to the repository
+1. creates a tag for the release
+1. uploads the firmware binary as an artifact to the GitHub
+
+`Release` refers to a GitHub release, not a firmware release or OTA update. This example does not trigger OTA updates.
+
+```yaml
+name: Tag and Release Firmware
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - product-firmware-src/**
+      - .github/**
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    outputs:
+      firmware-version: ${{ steps.compile.outputs.firmware-version }}
+      firmware-version-updated: ${{ steps.compile.outputs.firmware-version-updated }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Compile application
+        id: compile
+        uses: particle-iot/compile-action@v1
+        with:
+          particle-platform-name: 'boron'
+          device-os-version: 'latest-lts'
+          sources-folder: 'product-firmware-src'
+          auto-version: true
+
+      - name: Commit updated version file
+        if: steps.compile.outputs.firmware-version-updated == 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -m "Update firmware version" -a
+
+      # When a GitHub Action pushes commits or tags, it does not trigger a new GitHub Action job
+      - name: Push changes
+        if: steps.compile.outputs.firmware-version-updated == 'true'
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: firmware
+          path: ${{ steps.compile.outputs.artifact-path }}
+
+  create-release:
+    needs: compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: output
+
+      - name: Check if tag exists
+        id: check
+        run: |
+          git fetch --tags
+          tag="v${{ needs.compile.outputs.firmware-version }}"
+          tag_exists=$(git tag -l "$tag")
+          if [ -z "$tag_exists" ]; then
+            echo "Tag '$tag' does not exist. The pipeline will continue and create a new release."
+            echo "exists=false" >> $GITHUB_OUTPUT
+          else
+            echo "Tag '$tag' already exists. The pipeline will stop."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set tag and release variables
+        if: steps.check.outputs.exists == 'false'
+        id: set-vars
+        run: |
+          echo "artifacts=$(find ./output -type f -name "*.bin" | paste -sd, -)" >> $GITHUB_OUTPUT
+          echo "tag=v${{ needs.compile.outputs.firmware-version }}" >> $GITHUB_OUTPUT
+          echo "release-name=Firmware v${{ needs.compile.outputs.firmware-version }}" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git tag ${{ steps.set-vars.outputs.tag }}
+          git push --tags
+
+      - name: Create GitHub release and upload artifact
+        if: steps.check.outputs.exists == 'false'
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ steps.set-vars.outputs.artifacts }}
+          generateReleaseNotes: 'true'
+          name: ${{ steps.set-vars.outputs.release-name }}
+          tag: ${{ steps.set-vars.outputs.tag }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+

--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -174,7 +174,6 @@ on:
         required: true
         default: 'latest-lts'
 
-...
 jobs:
   compile:
     steps:

--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -27,181 +27,19 @@ The auto-versioning feature does not commit the updated version file to the repo
 ## Example Workflows
 
 Three example workflows are provided below:
- 1. Continuous versioning: create a new release every time the firmware code changes on the `main` branch
- 1. Semi-automated versioning: create a new release when you manually trigger the workflow
+
  1. Manual versioning: increment the version number manually (does not use automatic versioning)
-
-### Continuous Versioning
-
-This example workflow runs on every push to the `main` branch in the specified paths. It:
-
-1. compiles the firmware
-1. increments the version number if the firmware code has changed since the last version
-1. _if the version number was incremented, the workflow continues, otherwise it skips the remaining steps_
-1. commits the updated version file to the repository
-1. pushes the changes to the repository
-1. creates a tag for the release
-1. uploads the firmware binary as an artifact to the GitHub
-
-`Release` refers to a GitHub release, not a firmware release or OTA update. This example does not trigger OTA updates.
-
-```yaml
-name: Tag and Release Firmware
-
-on:
-  push:
-    branches:
-      - main
-    paths:
-      - product-firmware-src/**
-      - .github/**
-
-jobs:
-  compile:
-    runs-on: ubuntu-latest
-    outputs:
-      firmware-version: ${{ steps.compile.outputs.firmware-version }}
-      firmware-version-updated: ${{ steps.compile.outputs.firmware-version-updated }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Compile application
-        id: compile
-        uses: particle-iot/compile-action@v1
-        with:
-          particle-platform-name: 'boron'
-          device-os-version: 'latest-lts'
-          sources-folder: 'product-firmware-src'
-          auto-version: true
-
-      - name: Commit updated version file
-        if: steps.compile.outputs.firmware-version-updated == 'true'
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git commit -m "Update firmware version" -a
-
-      # When a GitHub Action pushes commits or tags, it does not trigger a new GitHub Action job
-      - name: Push changes
-        if: steps.compile.outputs.firmware-version-updated == 'true'
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: firmware
-          path: ${{ steps.compile.outputs.artifact-path }}
-
-  create-release:
-    needs: compile
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: output
-
-      - name: Check if tag exists
-        id: check
-        run: |
-          git fetch --tags
-          tag="v${{ needs.compile.outputs.firmware-version }}"
-          tag_exists=$(git tag -l "$tag")
-          if [ -z "$tag_exists" ]; then
-            echo "Tag '$tag' does not exist. The pipeline will continue and create a new release."
-            echo "exists=false" >> $GITHUB_OUTPUT
-          else
-            echo "Tag '$tag' already exists. The pipeline will stop."
-            echo "exists=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set tag and release variables
-        if: steps.check.outputs.exists == 'false'
-        id: set-vars
-        run: |
-          echo "artifacts=$(find ./output -type f -name "*.bin" | paste -sd, -)" >> $GITHUB_OUTPUT
-          echo "tag=v${{ needs.compile.outputs.firmware-version }}" >> $GITHUB_OUTPUT
-          echo "release-name=Firmware v${{ needs.compile.outputs.firmware-version }}" >> $GITHUB_OUTPUT
-
-      - name: Create and push tag
-        if: steps.check.outputs.exists == 'false'
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git tag ${{ steps.set-vars.outputs.tag }}
-          git push --tags
-
-      - name: Create GitHub release and upload artifact
-        if: steps.check.outputs.exists == 'false'
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: ${{ steps.set-vars.outputs.artifacts }}
-          generateReleaseNotes: 'true'
-          name: ${{ steps.set-vars.outputs.release-name }}
-          tag: ${{ steps.set-vars.outputs.tag }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-```
-
-### Semi-automated Versioning
-
-We can adapt the above workflow to only increment the version number when we manually trigger the workflow.
-
-This approach lets you accumulate changes in the repository and then trigger a release when you are ready.
-
-```yaml
-
-# This workflow runs when we manually trigger it.
-# Trigger it by going to the Actions tab in your repository and clicking the "Run workflow" button.
-# You will be prompted to enter the Particle platform name and Device OS version.
-on:
-  workflow_dispatch:
-    inputs:
-      platform:
-        description: 'Particle platform name'
-        required: true
-        default: 'boron'
-      device-os-version:
-        description: 'Device OS version'
-        required: true
-        default: 'latest-lts'
-
-jobs:
-  compile:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      
-      - name: Compile application
-        id: compile
-        uses: particle-iot/compile-action@v1
-        with:
-          particle-platform-name: ${{ github.event.inputs.platform }}
-          device-os-version: ${{ github.event.inputs.device-os-version }}
-          sources-folder: 'product-firmware-src'
-          auto-version: true
-       
-      # Same as above
-```
+ 1. Semi-automated versioning: create a new release when you manually trigger the workflow
+ 1. Continuous versioning: create a new release every time the firmware code changes on the `main` branch
 
 ### Manual Versioning
 
-This example does not use auto-versioning. 
+This example does not use auto-versioning.
 
-You need to manually update the version number and create a git tag. 
+You need to manually update the version number and create a git tag that matches the version number.
 
 ```yaml
+name: Compile and Release
 
 # This workflow runs on git tags
 # It will only run when a tag is pushed to the repository that matches the pattern "v*"
@@ -237,4 +75,102 @@ jobs:
           generateReleaseNotes: 'true'
           name: "Firmware ${{ steps.compile.outputs.firmware-version }}"
           token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Semi-automated Versioning
+
+Manually triggering this workflow will:
+
+1. compile the firmware
+1. increment the version number if the firmware code has changed since the last version
+1. _if the version number was incremented, the workflow continues, otherwise it skips the remaining steps_
+1. commit the updated version file to the repository
+1. push the changes to the repository
+1. create a tag for the release
+1. upload the firmware binary as an artifact to the GitHub
+
+This approach lets you accumulate changes in the repository and then trigger a release when you are ready.
+
+`Release` refers to a GitHub release, not a firmware release or OTA update. This example does not trigger OTA updates.
+
+
+```yaml
+name: Compile and Release
+
+# This workflow runs when we manually trigger it.
+# Trigger it by going to the Actions tab in your repository and clicking the "Run workflow" button.
+on:
+  workflow_dispatch:
+
+jobs:
+  compile-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      
+      - name: Compile application
+        id: compile
+        uses: particle-iot/compile-action@v1
+        with:
+          particle-platform-name: 'boron'
+          device-os-version: 'latest-lts'
+          sources-folder: 'product-firmware-src'
+          auto-version: true
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ steps.compile.outputs.artifact-path }}
+
+      - name: Commit updated version file
+        if: steps.compile.outputs.firmware-version-updated == 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -m "Update firmware version" -a
+
+      # When a GitHub Action pushes commits or tags, it does not trigger a new GitHub Action job
+      - name: Push changes
+        if: steps.compile.outputs.firmware-version-updated == 'true'
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+
+      - name: Create GitHub release
+        if: steps.compile.outputs.firmware-version-updated == 'true'
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ steps.compile.outputs.artifact-path }}
+          generateReleaseNotes: 'true'
+          name: "Firmware ${{ steps.compile.outputs.firmware-version }}"
+          tag: "v${{ steps.compile.outputs.firmware-version }}"
+          commit: ${{ github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Continuous Versioning
+
+This example workflow runs on every push to the `main` branch in the specified paths.
+
+Every merged pull request or commit pushed to `main` will trigger a new release.
+
+```yaml
+name: Compile and Release
+
+# This workflow runs on every push to the main branch in the specified paths.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - product-firmware-src/**
+      - .github/**
+
+jobs:
+  compile-release:
+    # Same as the semi-automated example above
 ```

--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -32,6 +32,8 @@ Three example workflows are provided below:
  1. Semi-automated versioning: create a new release when you manually trigger the workflow
  1. Continuous versioning: create a new release every time the firmware code changes on the `main` branch
 
+`Release` refers to a GitHub release, not a firmware release or OTA update. The examples do not trigger OTA updates.
+
 ### Manual Versioning
 
 This example does not use auto-versioning.
@@ -73,26 +75,15 @@ jobs:
         with:
           artifacts: ${{ steps.compile.outputs.artifact-path }}
           generateReleaseNotes: 'true'
-          name: "Firmware ${{ steps.compile.outputs.firmware-version }}"
+          name: "Firmware v${{ steps.compile.outputs.firmware-version }}"
           token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Semi-automated Versioning
 
-Manually triggering this workflow will:
-
-1. compile the firmware
-1. increment the version number if the firmware code has changed since the last version
-1. _if the version number was incremented, the workflow continues, otherwise it skips the remaining steps_
-1. commit the updated version file to the repository
-1. push the changes to the repository
-1. create a tag for the release
-1. upload the firmware binary as an artifact to the GitHub
+This example automatically increments the product firmware version when you manually trigger the workflow.
 
 This approach lets you accumulate changes in the repository and then trigger a release when you are ready.
-
-`Release` refers to a GitHub release, not a firmware release or OTA update. This example does not trigger OTA updates.
-
 
 ```yaml
 name: Compile and Release
@@ -146,7 +137,7 @@ jobs:
         with:
           artifacts: ${{ steps.compile.outputs.artifact-path }}
           generateReleaseNotes: 'true'
-          name: "Firmware ${{ steps.compile.outputs.firmware-version }}"
+          name: "Firmware v${{ steps.compile.outputs.firmware-version }}"
           tag: "v${{ steps.compile.outputs.firmware-version }}"
           commit: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -154,7 +145,7 @@ jobs:
 
 ### Continuous Versioning
 
-This example workflow runs on every push to the `main` branch in the specified paths.
+This workflow automatically increments the product firmware version on every push to the `main` branch in the specified paths.
 
 Every merged pull request or commit pushed to `main` will trigger a new release.
 

--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -1,0 +1,3 @@
+# Automatic Product Firmware Versioning
+
+todo

--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -176,6 +176,7 @@ on:
 
 jobs:
   compile:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -210,12 +211,11 @@ on:
       - 'v*'
 
 jobs:
-  compile:
+  compile-release:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Compile application
         id: compile
@@ -224,6 +224,17 @@ jobs:
           particle-platform-name: 'boron'
           device-os-version: 'latest-lts'
           sources-folder: 'product-firmware-src'
-          auto-version: false
 
-       # A combination of the tag and release automation steps from above if you want to create a GitHub release
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ steps.compile.outputs.artifact-path }}
+
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ steps.compile.outputs.artifact-path }}
+          generateReleaseNotes: 'true'
+          name: "Firmware ${{ steps.compile.outputs.firmware-version }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ A GitHub Action to compile Particle application firmware
 
 * `artifact-path`: Path to the compiled binary artifact. Typically, it will be `output/firmware.bin`
 * `device-os-version`: The Device OS version that was used for compilation. This may differ from the requested version if the requested version is a semver range or `latest` or `latest-lts`. Example: `2.3.1`
-* `firmware-version`: If auto-version is enabled, this output contains the product firmware version integer. Example: 2. The output value is undefined when sources are not a product firmware or auto-version is disabled.
-* `firmware-version-updated`: If auto-version is enabled, this output contains a boolean value indicating whether the product firmware version was updated. The output value is undefined when sources are not a product firmware or auto-version is disabled.
+* `firmware-version`: The product firmware version integer. This output is undefined when sources are not a product firmware.
+* `firmware-version-updated`: Boolean value indicating whether the product firmware version was updated. Can only be true with auto-version enabled.
 
 ### Example Pipeline
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ A GitHub Action to compile Particle application firmware
     # Required: false
     device-os-version: 'latest-lts'
       
+    # Auto versioning for product firmware
+    # If true, the action will automatically increment the product firmware version. See AUTO_VERSION.md for more details.
+    # Required: false
+    auto-version: 'false'
+
+    # Macro name for product firmware version
+    # Required: false
+    auto-version-macro-name: 'PRODUCT_VERSION'
+    
     # Particle access token
     # If provided, the action will use the Particle Cloud Compiler instead of compiling within the GitHub Action runner
     # Required: false
@@ -37,6 +46,7 @@ A GitHub Action to compile Particle application firmware
 
 * `artifact-path`: Path to the compiled binary artifact. Typically, it will be `output/firmware.bin`
 * `device-os-version`: The Device OS version that was used for compilation. This may differ from the requested version if the requested version is a semver range or `latest` or `latest-lts`. Example: `2.3.1`
+* `firmware-version`: If auto-version is enabled, this output contains the product firmware version integer. Example: 2. The output value is undefined when sources are not a product firmware or auto-version is disabled.
 
 ### Example Pipeline
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A GitHub Action to compile Particle application firmware
 * `artifact-path`: Path to the compiled binary artifact. Typically, it will be `output/firmware.bin`
 * `device-os-version`: The Device OS version that was used for compilation. This may differ from the requested version if the requested version is a semver range or `latest` or `latest-lts`. Example: `2.3.1`
 * `firmware-version`: If auto-version is enabled, this output contains the product firmware version integer. Example: 2. The output value is undefined when sources are not a product firmware or auto-version is disabled.
+* `firmware-version-updated`: If auto-version is enabled, this output contains a boolean value indicating whether the product firmware version was updated. The output value is undefined when sources are not a product firmware or auto-version is disabled.
 
 ### Example Pipeline
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A GitHub Action to compile Particle application firmware
 
 ### Outputs
 
-* `artifact-path`: Path to the compiled binary artifact. Typically, it will be `output/firmware.bin`
+* `artifact-path`: Path to the compiled binary artifact. Example: `output/firmware-argon-2.3.1.bin`
 * `device-os-version`: The Device OS version that was used for compilation. This may differ from the requested version if the requested version is a semver range or `latest` or `latest-lts`. Example: `2.3.1`
 * `firmware-version`: The product firmware version integer. This output is undefined when sources are not a product firmware.
 * `firmware-version-updated`: Boolean value indicating whether the product firmware version was updated. Can only be true with auto-version enabled.

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,8 @@ outputs:
     description: 'This output contains the actual Device OS version used for compilation. Example: 4.0.2'
   firmware-version:
     description: 'If auto-version is enabled, this output contains the product firmware version integer. Example: 2. The output value is undefined when sources are not a product firmware or auto-version is disabled.'
+  firmware-version-updated:
+    description: 'If auto-version is enabled, this output contains a boolean value indicating whether the product firmware version was updated. The output value is undefined when sources are not a product firmware or auto-version is disabled.'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: 'PRODUCT_VERSION'
 outputs:
   artifact-path:
-    description: 'Path to the compiled binary file. Example: output/firmware.bin'
+    description: 'Path to the compiled binary file. Example: output/firmware-argon-2.3.1.bin'
   device-os-version:
     description: 'This output contains the actual Device OS version used for compilation. Example: 4.0.2'
   firmware-version:

--- a/action.yml
+++ b/action.yml
@@ -17,11 +17,21 @@ inputs:
     required: false
     description: 'Path to directory with sources to compile. Example: src'
     default: 'src'
+  auto-version:
+    required: false
+    description: 'If true, the action will automatically increment the product firmware version. See AUTO_VERSION.md for more details.'
+    default: 'false'
+  auto-version-macro-name:
+    required: false
+    description: 'Name of the macro that contains the product firmware version.'
+    default: 'PRODUCT_VERSION'
 outputs:
   artifact-path:
     description: 'Path to the compiled binary file. Example: output/firmware.bin'
   device-os-version:
     description: 'This output contains the actual Device OS version used for compilation. Example: 4.0.2'
+  firmware-version:
+    description: 'If auto-version is enabled, this output contains the product firmware version integer. Example: 2. The output value is undefined when sources are not a product firmware or auto-version is disabled.'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -31,9 +31,9 @@ outputs:
   device-os-version:
     description: 'This output contains the actual Device OS version used for compilation. Example: 4.0.2'
   firmware-version:
-    description: 'If auto-version is enabled, this output contains the product firmware version integer. Example: 2. The output value is undefined when sources are not a product firmware or auto-version is disabled.'
+    description: 'The product firmware version integer. This output is undefined when sources are not a product firmware.'
   firmware-version-updated:
-    description: 'If auto-version is enabled, this output contains a boolean value indicating whether the product firmware version was updated. The output value is undefined when sources are not a product firmware or auto-version is disabled.'
+    description: 'Boolean value indicating whether the product firmware version was updated. Can only be true with auto-version enabled.'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1777,6 +1777,148 @@ function isLoopbackAddress(host) {
 
 /***/ }),
 
+/***/ 4751:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+__export(__nccwpck_require__(2825));
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ 2825:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const fs_1 = __nccwpck_require__(7147);
+const debug_1 = __importDefault(__nccwpck_require__(8237));
+const log = debug_1.default('@kwsites/file-exists');
+function check(path, isFile, isDirectory) {
+    log(`checking %s`, path);
+    try {
+        const stat = fs_1.statSync(path);
+        if (stat.isFile() && isFile) {
+            log(`[OK] path represents a file`);
+            return true;
+        }
+        if (stat.isDirectory() && isDirectory) {
+            log(`[OK] path represents a directory`);
+            return true;
+        }
+        log(`[FAIL] path represents something other than a file or directory`);
+        return false;
+    }
+    catch (e) {
+        if (e.code === 'ENOENT') {
+            log(`[FAIL] path is not accessible: %o`, e);
+            return false;
+        }
+        log(`[FATAL] %o`, e);
+        throw e;
+    }
+}
+/**
+ * Synchronous validation of a path existing either as a file or as a directory.
+ *
+ * @param {string} path The path to check
+ * @param {number} type One or both of the exported numeric constants
+ */
+function exists(path, type = exports.READABLE) {
+    return check(path, (type & exports.FILE) > 0, (type & exports.FOLDER) > 0);
+}
+exports.exists = exists;
+/**
+ * Constant representing a file
+ */
+exports.FILE = 1;
+/**
+ * Constant representing a folder
+ */
+exports.FOLDER = 2;
+/**
+ * Constant representing either a file or a folder
+ */
+exports.READABLE = exports.FILE + exports.FOLDER;
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ 7613:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.createDeferred = exports.deferred = void 0;
+/**
+ * Creates a new `DeferredPromise`
+ *
+ * ```typescript
+ import {deferred} from '@kwsites/promise-deferred`;
+ ```
+ */
+function deferred() {
+    let done;
+    let fail;
+    let status = 'pending';
+    const promise = new Promise((_done, _fail) => {
+        done = _done;
+        fail = _fail;
+    });
+    return {
+        promise,
+        done(result) {
+            if (status === 'pending') {
+                status = 'resolved';
+                done(result);
+            }
+        },
+        fail(error) {
+            if (status === 'pending') {
+                status = 'rejected';
+                fail(error);
+            }
+        },
+        get fulfilled() {
+            return status !== 'pending';
+        },
+        get status() {
+            return status;
+        },
+    };
+}
+exports.deferred = deferred;
+/**
+ * Alias of the exported `deferred` function, to help consumers wanting to use `deferred` as the
+ * local variable name rather than the factory import name, without needing to rename on import.
+ *
+ * ```typescript
+ import {createDeferred} from '@kwsites/promise-deferred`;
+ ```
+ */
+exports.createDeferred = deferred;
+/**
+ * Default export allows use as:
+ *
+ * ```typescript
+ import deferred from '@kwsites/promise-deferred`;
+ ```
+ */
+exports["default"] = deferred;
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
 /***/ 4812:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -24591,6 +24733,4196 @@ if (process.platform === 'linux') {
 
 /***/ }),
 
+/***/ 9103:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __defProps = Object.defineProperties;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getOwnPropSymbols = Object.getOwnPropertySymbols;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __propIsEnum = Object.prototype.propertyIsEnumerable;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __spreadValues = (a, b) => {
+  for (var prop in b || (b = {}))
+    if (__hasOwnProp.call(b, prop))
+      __defNormalProp(a, prop, b[prop]);
+  if (__getOwnPropSymbols)
+    for (var prop of __getOwnPropSymbols(b)) {
+      if (__propIsEnum.call(b, prop))
+        __defNormalProp(a, prop, b[prop]);
+    }
+  return a;
+};
+var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));
+var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
+var __esm = (fn, res) => function __init() {
+  return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+};
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __reExport = (target, module2, copyDefault, desc) => {
+  if (module2 && typeof module2 === "object" || typeof module2 === "function") {
+    for (let key of __getOwnPropNames(module2))
+      if (!__hasOwnProp.call(target, key) && (copyDefault || key !== "default"))
+        __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
+  }
+  return target;
+};
+var __toESM = (module2, isNodeMode) => {
+  return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", !isNodeMode && module2 && module2.__esModule ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
+};
+var __toCommonJS = /* @__PURE__ */ ((cache) => {
+  return (module2, temp) => {
+    return cache && cache.get(module2) || (temp = __reExport(__markAsModule({}), module2, 1), cache && cache.set(module2, temp), temp);
+  };
+})(typeof WeakMap !== "undefined" ? /* @__PURE__ */ new WeakMap() : 0);
+var __async = (__this, __arguments, generator) => {
+  return new Promise((resolve, reject) => {
+    var fulfilled = (value) => {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    };
+    var rejected = (value) => {
+      try {
+        step(generator.throw(value));
+      } catch (e) {
+        reject(e);
+      }
+    };
+    var step = (x) => x.done ? resolve(x.value) : Promise.resolve(x.value).then(fulfilled, rejected);
+    step((generator = generator.apply(__this, __arguments)).next());
+  });
+};
+
+// src/lib/errors/git-error.ts
+var GitError;
+var init_git_error = __esm({
+  "src/lib/errors/git-error.ts"() {
+    GitError = class extends Error {
+      constructor(task, message) {
+        super(message);
+        this.task = task;
+        Object.setPrototypeOf(this, new.target.prototype);
+      }
+    };
+  }
+});
+
+// src/lib/errors/git-response-error.ts
+var GitResponseError;
+var init_git_response_error = __esm({
+  "src/lib/errors/git-response-error.ts"() {
+    init_git_error();
+    GitResponseError = class extends GitError {
+      constructor(git, message) {
+        super(void 0, message || String(git));
+        this.git = git;
+      }
+    };
+  }
+});
+
+// src/lib/errors/git-construct-error.ts
+var GitConstructError;
+var init_git_construct_error = __esm({
+  "src/lib/errors/git-construct-error.ts"() {
+    init_git_error();
+    GitConstructError = class extends GitError {
+      constructor(config, message) {
+        super(void 0, message);
+        this.config = config;
+      }
+    };
+  }
+});
+
+// src/lib/errors/git-plugin-error.ts
+var GitPluginError;
+var init_git_plugin_error = __esm({
+  "src/lib/errors/git-plugin-error.ts"() {
+    init_git_error();
+    GitPluginError = class extends GitError {
+      constructor(task, plugin, message) {
+        super(task, message);
+        this.task = task;
+        this.plugin = plugin;
+        Object.setPrototypeOf(this, new.target.prototype);
+      }
+    };
+  }
+});
+
+// src/lib/errors/task-configuration-error.ts
+var TaskConfigurationError;
+var init_task_configuration_error = __esm({
+  "src/lib/errors/task-configuration-error.ts"() {
+    init_git_error();
+    TaskConfigurationError = class extends GitError {
+      constructor(message) {
+        super(void 0, message);
+      }
+    };
+  }
+});
+
+// src/lib/utils/util.ts
+function asFunction(source) {
+  return typeof source === "function" ? source : NOOP;
+}
+function isUserFunction(source) {
+  return typeof source === "function" && source !== NOOP;
+}
+function splitOn(input, char) {
+  const index = input.indexOf(char);
+  if (index <= 0) {
+    return [input, ""];
+  }
+  return [input.substr(0, index), input.substr(index + 1)];
+}
+function first(input, offset = 0) {
+  return isArrayLike(input) && input.length > offset ? input[offset] : void 0;
+}
+function last(input, offset = 0) {
+  if (isArrayLike(input) && input.length > offset) {
+    return input[input.length - 1 - offset];
+  }
+}
+function isArrayLike(input) {
+  return !!(input && typeof input.length === "number");
+}
+function toLinesWithContent(input = "", trimmed2 = true, separator = "\n") {
+  return input.split(separator).reduce((output, line) => {
+    const lineContent = trimmed2 ? line.trim() : line;
+    if (lineContent) {
+      output.push(lineContent);
+    }
+    return output;
+  }, []);
+}
+function forEachLineWithContent(input, callback) {
+  return toLinesWithContent(input, true).map((line) => callback(line));
+}
+function folderExists(path) {
+  return (0, import_file_exists.exists)(path, import_file_exists.FOLDER);
+}
+function append(target, item) {
+  if (Array.isArray(target)) {
+    if (!target.includes(item)) {
+      target.push(item);
+    }
+  } else {
+    target.add(item);
+  }
+  return item;
+}
+function including(target, item) {
+  if (Array.isArray(target) && !target.includes(item)) {
+    target.push(item);
+  }
+  return target;
+}
+function remove(target, item) {
+  if (Array.isArray(target)) {
+    const index = target.indexOf(item);
+    if (index >= 0) {
+      target.splice(index, 1);
+    }
+  } else {
+    target.delete(item);
+  }
+  return item;
+}
+function asArray(source) {
+  return Array.isArray(source) ? source : [source];
+}
+function asStringArray(source) {
+  return asArray(source).map(String);
+}
+function asNumber(source, onNaN = 0) {
+  if (source == null) {
+    return onNaN;
+  }
+  const num = parseInt(source, 10);
+  return isNaN(num) ? onNaN : num;
+}
+function prefixedArray(input, prefix) {
+  const output = [];
+  for (let i = 0, max = input.length; i < max; i++) {
+    output.push(prefix, input[i]);
+  }
+  return output;
+}
+function bufferToString(input) {
+  return (Array.isArray(input) ? Buffer.concat(input) : input).toString("utf-8");
+}
+function pick(source, properties) {
+  return Object.assign({}, ...properties.map((property) => property in source ? { [property]: source[property] } : {}));
+}
+function delay(duration = 0) {
+  return new Promise((done) => setTimeout(done, duration));
+}
+var import_file_exists, NULL, NOOP, objectToString;
+var init_util = __esm({
+  "src/lib/utils/util.ts"() {
+    import_file_exists = __nccwpck_require__(4751);
+    NULL = "\0";
+    NOOP = () => {
+    };
+    objectToString = Object.prototype.toString.call.bind(Object.prototype.toString);
+  }
+});
+
+// src/lib/utils/argument-filters.ts
+function filterType(input, filter, def) {
+  if (filter(input)) {
+    return input;
+  }
+  return arguments.length > 2 ? def : void 0;
+}
+function filterPrimitives(input, omit) {
+  return /number|string|boolean/.test(typeof input) && (!omit || !omit.includes(typeof input));
+}
+function filterPlainObject(input) {
+  return !!input && objectToString(input) === "[object Object]";
+}
+function filterFunction(input) {
+  return typeof input === "function";
+}
+var filterArray, filterString, filterStringArray, filterStringOrStringArray, filterHasLength;
+var init_argument_filters = __esm({
+  "src/lib/utils/argument-filters.ts"() {
+    init_util();
+    filterArray = (input) => {
+      return Array.isArray(input);
+    };
+    filterString = (input) => {
+      return typeof input === "string";
+    };
+    filterStringArray = (input) => {
+      return Array.isArray(input) && input.every(filterString);
+    };
+    filterStringOrStringArray = (input) => {
+      return filterString(input) || Array.isArray(input) && input.every(filterString);
+    };
+    filterHasLength = (input) => {
+      if (input == null || "number|boolean|function".includes(typeof input)) {
+        return false;
+      }
+      return Array.isArray(input) || typeof input === "string" || typeof input.length === "number";
+    };
+  }
+});
+
+// src/lib/utils/exit-codes.ts
+var ExitCodes;
+var init_exit_codes = __esm({
+  "src/lib/utils/exit-codes.ts"() {
+    ExitCodes = /* @__PURE__ */ ((ExitCodes2) => {
+      ExitCodes2[ExitCodes2["SUCCESS"] = 0] = "SUCCESS";
+      ExitCodes2[ExitCodes2["ERROR"] = 1] = "ERROR";
+      ExitCodes2[ExitCodes2["NOT_FOUND"] = -2] = "NOT_FOUND";
+      ExitCodes2[ExitCodes2["UNCLEAN"] = 128] = "UNCLEAN";
+      return ExitCodes2;
+    })(ExitCodes || {});
+  }
+});
+
+// src/lib/utils/git-output-streams.ts
+var GitOutputStreams;
+var init_git_output_streams = __esm({
+  "src/lib/utils/git-output-streams.ts"() {
+    GitOutputStreams = class {
+      constructor(stdOut, stdErr) {
+        this.stdOut = stdOut;
+        this.stdErr = stdErr;
+      }
+      asStrings() {
+        return new GitOutputStreams(this.stdOut.toString("utf8"), this.stdErr.toString("utf8"));
+      }
+    };
+  }
+});
+
+// src/lib/utils/line-parser.ts
+var LineParser, RemoteLineParser;
+var init_line_parser = __esm({
+  "src/lib/utils/line-parser.ts"() {
+    LineParser = class {
+      constructor(regExp, useMatches) {
+        this.matches = [];
+        this.parse = (line, target) => {
+          this.resetMatches();
+          if (!this._regExp.every((reg, index) => this.addMatch(reg, index, line(index)))) {
+            return false;
+          }
+          return this.useMatches(target, this.prepareMatches()) !== false;
+        };
+        this._regExp = Array.isArray(regExp) ? regExp : [regExp];
+        if (useMatches) {
+          this.useMatches = useMatches;
+        }
+      }
+      useMatches(target, match) {
+        throw new Error(`LineParser:useMatches not implemented`);
+      }
+      resetMatches() {
+        this.matches.length = 0;
+      }
+      prepareMatches() {
+        return this.matches;
+      }
+      addMatch(reg, index, line) {
+        const matched = line && reg.exec(line);
+        if (matched) {
+          this.pushMatch(index, matched);
+        }
+        return !!matched;
+      }
+      pushMatch(_index, matched) {
+        this.matches.push(...matched.slice(1));
+      }
+    };
+    RemoteLineParser = class extends LineParser {
+      addMatch(reg, index, line) {
+        return /^remote:\s/.test(String(line)) && super.addMatch(reg, index, line);
+      }
+      pushMatch(index, matched) {
+        if (index > 0 || matched.length > 1) {
+          super.pushMatch(index, matched);
+        }
+      }
+    };
+  }
+});
+
+// src/lib/utils/simple-git-options.ts
+function createInstanceConfig(...options) {
+  const baseDir = process.cwd();
+  const config = Object.assign(__spreadValues({ baseDir }, defaultOptions), ...options.filter((o) => typeof o === "object" && o));
+  config.baseDir = config.baseDir || baseDir;
+  config.trimmed = config.trimmed === true;
+  return config;
+}
+var defaultOptions;
+var init_simple_git_options = __esm({
+  "src/lib/utils/simple-git-options.ts"() {
+    defaultOptions = {
+      binary: "git",
+      maxConcurrentProcesses: 5,
+      config: [],
+      trimmed: false
+    };
+  }
+});
+
+// src/lib/utils/task-options.ts
+function appendTaskOptions(options, commands = []) {
+  if (!filterPlainObject(options)) {
+    return commands;
+  }
+  return Object.keys(options).reduce((commands2, key) => {
+    const value = options[key];
+    if (filterPrimitives(value, ["boolean"])) {
+      commands2.push(key + "=" + value);
+    } else {
+      commands2.push(key);
+    }
+    return commands2;
+  }, commands);
+}
+function getTrailingOptions(args, initialPrimitive = 0, objectOnly = false) {
+  const command = [];
+  for (let i = 0, max = initialPrimitive < 0 ? args.length : initialPrimitive; i < max; i++) {
+    if ("string|number".includes(typeof args[i])) {
+      command.push(String(args[i]));
+    }
+  }
+  appendTaskOptions(trailingOptionsArgument(args), command);
+  if (!objectOnly) {
+    command.push(...trailingArrayArgument(args));
+  }
+  return command;
+}
+function trailingArrayArgument(args) {
+  const hasTrailingCallback = typeof last(args) === "function";
+  return filterType(last(args, hasTrailingCallback ? 1 : 0), filterArray, []);
+}
+function trailingOptionsArgument(args) {
+  const hasTrailingCallback = filterFunction(last(args));
+  return filterType(last(args, hasTrailingCallback ? 1 : 0), filterPlainObject);
+}
+function trailingFunctionArgument(args, includeNoop = true) {
+  const callback = asFunction(last(args));
+  return includeNoop || isUserFunction(callback) ? callback : void 0;
+}
+var init_task_options = __esm({
+  "src/lib/utils/task-options.ts"() {
+    init_argument_filters();
+    init_util();
+  }
+});
+
+// src/lib/utils/task-parser.ts
+function callTaskParser(parser3, streams) {
+  return parser3(streams.stdOut, streams.stdErr);
+}
+function parseStringResponse(result, parsers12, texts, trim = true) {
+  asArray(texts).forEach((text) => {
+    for (let lines = toLinesWithContent(text, trim), i = 0, max = lines.length; i < max; i++) {
+      const line = (offset = 0) => {
+        if (i + offset >= max) {
+          return;
+        }
+        return lines[i + offset];
+      };
+      parsers12.some(({ parse }) => parse(line, result));
+    }
+  });
+  return result;
+}
+var init_task_parser = __esm({
+  "src/lib/utils/task-parser.ts"() {
+    init_util();
+  }
+});
+
+// src/lib/utils/index.ts
+var utils_exports = {};
+__export(utils_exports, {
+  ExitCodes: () => ExitCodes,
+  GitOutputStreams: () => GitOutputStreams,
+  LineParser: () => LineParser,
+  NOOP: () => NOOP,
+  NULL: () => NULL,
+  RemoteLineParser: () => RemoteLineParser,
+  append: () => append,
+  appendTaskOptions: () => appendTaskOptions,
+  asArray: () => asArray,
+  asFunction: () => asFunction,
+  asNumber: () => asNumber,
+  asStringArray: () => asStringArray,
+  bufferToString: () => bufferToString,
+  callTaskParser: () => callTaskParser,
+  createInstanceConfig: () => createInstanceConfig,
+  delay: () => delay,
+  filterArray: () => filterArray,
+  filterFunction: () => filterFunction,
+  filterHasLength: () => filterHasLength,
+  filterPlainObject: () => filterPlainObject,
+  filterPrimitives: () => filterPrimitives,
+  filterString: () => filterString,
+  filterStringArray: () => filterStringArray,
+  filterStringOrStringArray: () => filterStringOrStringArray,
+  filterType: () => filterType,
+  first: () => first,
+  folderExists: () => folderExists,
+  forEachLineWithContent: () => forEachLineWithContent,
+  getTrailingOptions: () => getTrailingOptions,
+  including: () => including,
+  isUserFunction: () => isUserFunction,
+  last: () => last,
+  objectToString: () => objectToString,
+  parseStringResponse: () => parseStringResponse,
+  pick: () => pick,
+  prefixedArray: () => prefixedArray,
+  remove: () => remove,
+  splitOn: () => splitOn,
+  toLinesWithContent: () => toLinesWithContent,
+  trailingFunctionArgument: () => trailingFunctionArgument,
+  trailingOptionsArgument: () => trailingOptionsArgument
+});
+var init_utils = __esm({
+  "src/lib/utils/index.ts"() {
+    init_argument_filters();
+    init_exit_codes();
+    init_git_output_streams();
+    init_line_parser();
+    init_simple_git_options();
+    init_task_options();
+    init_task_parser();
+    init_util();
+  }
+});
+
+// src/lib/tasks/check-is-repo.ts
+var check_is_repo_exports = {};
+__export(check_is_repo_exports, {
+  CheckRepoActions: () => CheckRepoActions,
+  checkIsBareRepoTask: () => checkIsBareRepoTask,
+  checkIsRepoRootTask: () => checkIsRepoRootTask,
+  checkIsRepoTask: () => checkIsRepoTask
+});
+function checkIsRepoTask(action) {
+  switch (action) {
+    case "bare" /* BARE */:
+      return checkIsBareRepoTask();
+    case "root" /* IS_REPO_ROOT */:
+      return checkIsRepoRootTask();
+  }
+  const commands = ["rev-parse", "--is-inside-work-tree"];
+  return {
+    commands,
+    format: "utf-8",
+    onError,
+    parser
+  };
+}
+function checkIsRepoRootTask() {
+  const commands = ["rev-parse", "--git-dir"];
+  return {
+    commands,
+    format: "utf-8",
+    onError,
+    parser(path) {
+      return /^\.(git)?$/.test(path.trim());
+    }
+  };
+}
+function checkIsBareRepoTask() {
+  const commands = ["rev-parse", "--is-bare-repository"];
+  return {
+    commands,
+    format: "utf-8",
+    onError,
+    parser
+  };
+}
+function isNotRepoMessage(error) {
+  return /(Not a git repository|Kein Git-Repository)/i.test(String(error));
+}
+var CheckRepoActions, onError, parser;
+var init_check_is_repo = __esm({
+  "src/lib/tasks/check-is-repo.ts"() {
+    init_utils();
+    CheckRepoActions = /* @__PURE__ */ ((CheckRepoActions2) => {
+      CheckRepoActions2["BARE"] = "bare";
+      CheckRepoActions2["IN_TREE"] = "tree";
+      CheckRepoActions2["IS_REPO_ROOT"] = "root";
+      return CheckRepoActions2;
+    })(CheckRepoActions || {});
+    onError = ({ exitCode }, error, done, fail) => {
+      if (exitCode === 128 /* UNCLEAN */ && isNotRepoMessage(error)) {
+        return done(Buffer.from("false"));
+      }
+      fail(error);
+    };
+    parser = (text) => {
+      return text.trim() === "true";
+    };
+  }
+});
+
+// src/lib/responses/CleanSummary.ts
+function cleanSummaryParser(dryRun, text) {
+  const summary = new CleanResponse(dryRun);
+  const regexp = dryRun ? dryRunRemovalRegexp : removalRegexp;
+  toLinesWithContent(text).forEach((line) => {
+    const removed = line.replace(regexp, "");
+    summary.paths.push(removed);
+    (isFolderRegexp.test(removed) ? summary.folders : summary.files).push(removed);
+  });
+  return summary;
+}
+var CleanResponse, removalRegexp, dryRunRemovalRegexp, isFolderRegexp;
+var init_CleanSummary = __esm({
+  "src/lib/responses/CleanSummary.ts"() {
+    init_utils();
+    CleanResponse = class {
+      constructor(dryRun) {
+        this.dryRun = dryRun;
+        this.paths = [];
+        this.files = [];
+        this.folders = [];
+      }
+    };
+    removalRegexp = /^[a-z]+\s*/i;
+    dryRunRemovalRegexp = /^[a-z]+\s+[a-z]+\s*/i;
+    isFolderRegexp = /\/$/;
+  }
+});
+
+// src/lib/tasks/task.ts
+var task_exports = {};
+__export(task_exports, {
+  EMPTY_COMMANDS: () => EMPTY_COMMANDS,
+  adhocExecTask: () => adhocExecTask,
+  configurationErrorTask: () => configurationErrorTask,
+  isBufferTask: () => isBufferTask,
+  isEmptyTask: () => isEmptyTask,
+  straightThroughBufferTask: () => straightThroughBufferTask,
+  straightThroughStringTask: () => straightThroughStringTask
+});
+function adhocExecTask(parser3) {
+  return {
+    commands: EMPTY_COMMANDS,
+    format: "empty",
+    parser: parser3
+  };
+}
+function configurationErrorTask(error) {
+  return {
+    commands: EMPTY_COMMANDS,
+    format: "empty",
+    parser() {
+      throw typeof error === "string" ? new TaskConfigurationError(error) : error;
+    }
+  };
+}
+function straightThroughStringTask(commands, trimmed2 = false) {
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return trimmed2 ? String(text).trim() : text;
+    }
+  };
+}
+function straightThroughBufferTask(commands) {
+  return {
+    commands,
+    format: "buffer",
+    parser(buffer) {
+      return buffer;
+    }
+  };
+}
+function isBufferTask(task) {
+  return task.format === "buffer";
+}
+function isEmptyTask(task) {
+  return task.format === "empty" || !task.commands.length;
+}
+var EMPTY_COMMANDS;
+var init_task = __esm({
+  "src/lib/tasks/task.ts"() {
+    init_task_configuration_error();
+    EMPTY_COMMANDS = [];
+  }
+});
+
+// src/lib/tasks/clean.ts
+var clean_exports = {};
+__export(clean_exports, {
+  CONFIG_ERROR_INTERACTIVE_MODE: () => CONFIG_ERROR_INTERACTIVE_MODE,
+  CONFIG_ERROR_MODE_REQUIRED: () => CONFIG_ERROR_MODE_REQUIRED,
+  CONFIG_ERROR_UNKNOWN_OPTION: () => CONFIG_ERROR_UNKNOWN_OPTION,
+  CleanOptions: () => CleanOptions,
+  cleanTask: () => cleanTask,
+  cleanWithOptionsTask: () => cleanWithOptionsTask,
+  isCleanOptionsArray: () => isCleanOptionsArray
+});
+function cleanWithOptionsTask(mode, customArgs) {
+  const { cleanMode, options, valid } = getCleanOptions(mode);
+  if (!cleanMode) {
+    return configurationErrorTask(CONFIG_ERROR_MODE_REQUIRED);
+  }
+  if (!valid.options) {
+    return configurationErrorTask(CONFIG_ERROR_UNKNOWN_OPTION + JSON.stringify(mode));
+  }
+  options.push(...customArgs);
+  if (options.some(isInteractiveMode)) {
+    return configurationErrorTask(CONFIG_ERROR_INTERACTIVE_MODE);
+  }
+  return cleanTask(cleanMode, options);
+}
+function cleanTask(mode, customArgs) {
+  const commands = ["clean", `-${mode}`, ...customArgs];
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return cleanSummaryParser(mode === "n" /* DRY_RUN */, text);
+    }
+  };
+}
+function isCleanOptionsArray(input) {
+  return Array.isArray(input) && input.every((test) => CleanOptionValues.has(test));
+}
+function getCleanOptions(input) {
+  let cleanMode;
+  let options = [];
+  let valid = { cleanMode: false, options: true };
+  input.replace(/[^a-z]i/g, "").split("").forEach((char) => {
+    if (isCleanMode(char)) {
+      cleanMode = char;
+      valid.cleanMode = true;
+    } else {
+      valid.options = valid.options && isKnownOption(options[options.length] = `-${char}`);
+    }
+  });
+  return {
+    cleanMode,
+    options,
+    valid
+  };
+}
+function isCleanMode(cleanMode) {
+  return cleanMode === "f" /* FORCE */ || cleanMode === "n" /* DRY_RUN */;
+}
+function isKnownOption(option) {
+  return /^-[a-z]$/i.test(option) && CleanOptionValues.has(option.charAt(1));
+}
+function isInteractiveMode(option) {
+  if (/^-[^\-]/.test(option)) {
+    return option.indexOf("i") > 0;
+  }
+  return option === "--interactive";
+}
+var CONFIG_ERROR_INTERACTIVE_MODE, CONFIG_ERROR_MODE_REQUIRED, CONFIG_ERROR_UNKNOWN_OPTION, CleanOptions, CleanOptionValues;
+var init_clean = __esm({
+  "src/lib/tasks/clean.ts"() {
+    init_CleanSummary();
+    init_utils();
+    init_task();
+    CONFIG_ERROR_INTERACTIVE_MODE = "Git clean interactive mode is not supported";
+    CONFIG_ERROR_MODE_REQUIRED = 'Git clean mode parameter ("n" or "f") is required';
+    CONFIG_ERROR_UNKNOWN_OPTION = "Git clean unknown option found in: ";
+    CleanOptions = /* @__PURE__ */ ((CleanOptions2) => {
+      CleanOptions2["DRY_RUN"] = "n";
+      CleanOptions2["FORCE"] = "f";
+      CleanOptions2["IGNORED_INCLUDED"] = "x";
+      CleanOptions2["IGNORED_ONLY"] = "X";
+      CleanOptions2["EXCLUDING"] = "e";
+      CleanOptions2["QUIET"] = "q";
+      CleanOptions2["RECURSIVE"] = "d";
+      return CleanOptions2;
+    })(CleanOptions || {});
+    CleanOptionValues = /* @__PURE__ */ new Set([
+      "i",
+      ...asStringArray(Object.values(CleanOptions))
+    ]);
+  }
+});
+
+// src/lib/responses/ConfigList.ts
+function configListParser(text) {
+  const config = new ConfigList();
+  for (const item of configParser(text)) {
+    config.addValue(item.file, String(item.key), item.value);
+  }
+  return config;
+}
+function configGetParser(text, key) {
+  let value = null;
+  const values = [];
+  const scopes = /* @__PURE__ */ new Map();
+  for (const item of configParser(text, key)) {
+    if (item.key !== key) {
+      continue;
+    }
+    values.push(value = item.value);
+    if (!scopes.has(item.file)) {
+      scopes.set(item.file, []);
+    }
+    scopes.get(item.file).push(value);
+  }
+  return {
+    key,
+    paths: Array.from(scopes.keys()),
+    scopes,
+    value,
+    values
+  };
+}
+function configFilePath(filePath) {
+  return filePath.replace(/^(file):/, "");
+}
+function* configParser(text, requestedKey = null) {
+  const lines = text.split("\0");
+  for (let i = 0, max = lines.length - 1; i < max; ) {
+    const file = configFilePath(lines[i++]);
+    let value = lines[i++];
+    let key = requestedKey;
+    if (value.includes("\n")) {
+      const line = splitOn(value, "\n");
+      key = line[0];
+      value = line[1];
+    }
+    yield { file, key, value };
+  }
+}
+var ConfigList;
+var init_ConfigList = __esm({
+  "src/lib/responses/ConfigList.ts"() {
+    init_utils();
+    ConfigList = class {
+      constructor() {
+        this.files = [];
+        this.values = /* @__PURE__ */ Object.create(null);
+      }
+      get all() {
+        if (!this._all) {
+          this._all = this.files.reduce((all, file) => {
+            return Object.assign(all, this.values[file]);
+          }, {});
+        }
+        return this._all;
+      }
+      addFile(file) {
+        if (!(file in this.values)) {
+          const latest = last(this.files);
+          this.values[file] = latest ? Object.create(this.values[latest]) : {};
+          this.files.push(file);
+        }
+        return this.values[file];
+      }
+      addValue(file, key, value) {
+        const values = this.addFile(file);
+        if (!values.hasOwnProperty(key)) {
+          values[key] = value;
+        } else if (Array.isArray(values[key])) {
+          values[key].push(value);
+        } else {
+          values[key] = [values[key], value];
+        }
+        this._all = void 0;
+      }
+    };
+  }
+});
+
+// src/lib/tasks/config.ts
+function asConfigScope(scope, fallback) {
+  if (typeof scope === "string" && GitConfigScope.hasOwnProperty(scope)) {
+    return scope;
+  }
+  return fallback;
+}
+function addConfigTask(key, value, append2, scope) {
+  const commands = ["config", `--${scope}`];
+  if (append2) {
+    commands.push("--add");
+  }
+  commands.push(key, value);
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return text;
+    }
+  };
+}
+function getConfigTask(key, scope) {
+  const commands = ["config", "--null", "--show-origin", "--get-all", key];
+  if (scope) {
+    commands.splice(1, 0, `--${scope}`);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return configGetParser(text, key);
+    }
+  };
+}
+function listConfigTask(scope) {
+  const commands = ["config", "--list", "--show-origin", "--null"];
+  if (scope) {
+    commands.push(`--${scope}`);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return configListParser(text);
+    }
+  };
+}
+function config_default() {
+  return {
+    addConfig(key, value, ...rest) {
+      return this._runTask(addConfigTask(key, value, rest[0] === true, asConfigScope(rest[1], "local" /* local */)), trailingFunctionArgument(arguments));
+    },
+    getConfig(key, scope) {
+      return this._runTask(getConfigTask(key, asConfigScope(scope, void 0)), trailingFunctionArgument(arguments));
+    },
+    listConfig(...rest) {
+      return this._runTask(listConfigTask(asConfigScope(rest[0], void 0)), trailingFunctionArgument(arguments));
+    }
+  };
+}
+var GitConfigScope;
+var init_config = __esm({
+  "src/lib/tasks/config.ts"() {
+    init_ConfigList();
+    init_utils();
+    GitConfigScope = /* @__PURE__ */ ((GitConfigScope2) => {
+      GitConfigScope2["system"] = "system";
+      GitConfigScope2["global"] = "global";
+      GitConfigScope2["local"] = "local";
+      GitConfigScope2["worktree"] = "worktree";
+      return GitConfigScope2;
+    })(GitConfigScope || {});
+  }
+});
+
+// src/lib/tasks/grep.ts
+function grepQueryBuilder(...params) {
+  return new GrepQuery().param(...params);
+}
+function parseGrep(grep) {
+  const paths = /* @__PURE__ */ new Set();
+  const results = {};
+  forEachLineWithContent(grep, (input) => {
+    const [path, line, preview] = input.split(NULL);
+    paths.add(path);
+    (results[path] = results[path] || []).push({
+      line: asNumber(line),
+      path,
+      preview
+    });
+  });
+  return {
+    paths,
+    results
+  };
+}
+function grep_default() {
+  return {
+    grep(searchTerm) {
+      const then = trailingFunctionArgument(arguments);
+      const options = getTrailingOptions(arguments);
+      for (const option of disallowedOptions) {
+        if (options.includes(option)) {
+          return this._runTask(configurationErrorTask(`git.grep: use of "${option}" is not supported.`), then);
+        }
+      }
+      if (typeof searchTerm === "string") {
+        searchTerm = grepQueryBuilder().param(searchTerm);
+      }
+      const commands = ["grep", "--null", "-n", "--full-name", ...options, ...searchTerm];
+      return this._runTask({
+        commands,
+        format: "utf-8",
+        parser(stdOut) {
+          return parseGrep(stdOut);
+        }
+      }, then);
+    }
+  };
+}
+var disallowedOptions, Query, _a, GrepQuery;
+var init_grep = __esm({
+  "src/lib/tasks/grep.ts"() {
+    init_utils();
+    init_task();
+    disallowedOptions = ["-h"];
+    Query = Symbol("grepQuery");
+    GrepQuery = class {
+      constructor() {
+        this[_a] = [];
+      }
+      *[(_a = Query, Symbol.iterator)]() {
+        for (const query of this[Query]) {
+          yield query;
+        }
+      }
+      and(...and) {
+        and.length && this[Query].push("--and", "(", ...prefixedArray(and, "-e"), ")");
+        return this;
+      }
+      param(...param) {
+        this[Query].push(...prefixedArray(param, "-e"));
+        return this;
+      }
+    };
+  }
+});
+
+// src/lib/tasks/reset.ts
+var reset_exports = {};
+__export(reset_exports, {
+  ResetMode: () => ResetMode,
+  getResetMode: () => getResetMode,
+  resetTask: () => resetTask
+});
+function resetTask(mode, customArgs) {
+  const commands = ["reset"];
+  if (isValidResetMode(mode)) {
+    commands.push(`--${mode}`);
+  }
+  commands.push(...customArgs);
+  return straightThroughStringTask(commands);
+}
+function getResetMode(mode) {
+  if (isValidResetMode(mode)) {
+    return mode;
+  }
+  switch (typeof mode) {
+    case "string":
+    case "undefined":
+      return "soft" /* SOFT */;
+  }
+  return;
+}
+function isValidResetMode(mode) {
+  return ResetModes.includes(mode);
+}
+var ResetMode, ResetModes;
+var init_reset = __esm({
+  "src/lib/tasks/reset.ts"() {
+    init_task();
+    ResetMode = /* @__PURE__ */ ((ResetMode2) => {
+      ResetMode2["MIXED"] = "mixed";
+      ResetMode2["SOFT"] = "soft";
+      ResetMode2["HARD"] = "hard";
+      ResetMode2["MERGE"] = "merge";
+      ResetMode2["KEEP"] = "keep";
+      return ResetMode2;
+    })(ResetMode || {});
+    ResetModes = Array.from(Object.values(ResetMode));
+  }
+});
+
+// src/lib/api.ts
+var api_exports = {};
+__export(api_exports, {
+  CheckRepoActions: () => CheckRepoActions,
+  CleanOptions: () => CleanOptions,
+  GitConfigScope: () => GitConfigScope,
+  GitConstructError: () => GitConstructError,
+  GitError: () => GitError,
+  GitPluginError: () => GitPluginError,
+  GitResponseError: () => GitResponseError,
+  ResetMode: () => ResetMode,
+  TaskConfigurationError: () => TaskConfigurationError,
+  grepQueryBuilder: () => grepQueryBuilder
+});
+var init_api = __esm({
+  "src/lib/api.ts"() {
+    init_git_construct_error();
+    init_git_error();
+    init_git_plugin_error();
+    init_git_response_error();
+    init_task_configuration_error();
+    init_check_is_repo();
+    init_clean();
+    init_config();
+    init_grep();
+    init_reset();
+  }
+});
+
+// src/lib/plugins/abort-plugin.ts
+function abortPlugin(signal) {
+  if (!signal) {
+    return;
+  }
+  const onSpawnAfter = {
+    type: "spawn.after",
+    action(_data, context) {
+      function kill() {
+        context.kill(new GitPluginError(void 0, "abort", "Abort signal received"));
+      }
+      signal.addEventListener("abort", kill);
+      context.spawned.on("close", () => signal.removeEventListener("abort", kill));
+    }
+  };
+  const onSpawnBefore = {
+    type: "spawn.before",
+    action(_data, context) {
+      if (signal.aborted) {
+        context.kill(new GitPluginError(void 0, "abort", "Abort already signaled"));
+      }
+    }
+  };
+  return [onSpawnBefore, onSpawnAfter];
+}
+var init_abort_plugin = __esm({
+  "src/lib/plugins/abort-plugin.ts"() {
+    init_git_plugin_error();
+  }
+});
+
+// src/lib/plugins/block-unsafe-operations-plugin.ts
+function isConfigSwitch(arg) {
+  return typeof arg === "string" && arg.trim().toLowerCase() === "-c";
+}
+function preventProtocolOverride(arg, next) {
+  if (!isConfigSwitch(arg)) {
+    return;
+  }
+  if (!/^\s*protocol(.[a-z]+)?.allow/.test(next)) {
+    return;
+  }
+  throw new GitPluginError(void 0, "unsafe", "Configuring protocol.allow is not permitted without enabling allowUnsafeExtProtocol");
+}
+function preventUploadPack(arg, method) {
+  if (/^\s*--(upload|receive)-pack/.test(arg)) {
+    throw new GitPluginError(void 0, "unsafe", `Use of --upload-pack or --receive-pack is not permitted without enabling allowUnsafePack`);
+  }
+  if (method === "clone" && /^\s*-u\b/.test(arg)) {
+    throw new GitPluginError(void 0, "unsafe", `Use of clone with option -u is not permitted without enabling allowUnsafePack`);
+  }
+  if (method === "push" && /^\s*--exec\b/.test(arg)) {
+    throw new GitPluginError(void 0, "unsafe", `Use of push with option --exec is not permitted without enabling allowUnsafePack`);
+  }
+}
+function blockUnsafeOperationsPlugin({
+  allowUnsafeProtocolOverride = false,
+  allowUnsafePack = false
+} = {}) {
+  return {
+    type: "spawn.args",
+    action(args, context) {
+      args.forEach((current, index) => {
+        const next = index < args.length ? args[index + 1] : "";
+        allowUnsafeProtocolOverride || preventProtocolOverride(current, next);
+        allowUnsafePack || preventUploadPack(current, context.method);
+      });
+      return args;
+    }
+  };
+}
+var init_block_unsafe_operations_plugin = __esm({
+  "src/lib/plugins/block-unsafe-operations-plugin.ts"() {
+    init_git_plugin_error();
+  }
+});
+
+// src/lib/plugins/command-config-prefixing-plugin.ts
+function commandConfigPrefixingPlugin(configuration) {
+  const prefix = prefixedArray(configuration, "-c");
+  return {
+    type: "spawn.args",
+    action(data) {
+      return [...prefix, ...data];
+    }
+  };
+}
+var init_command_config_prefixing_plugin = __esm({
+  "src/lib/plugins/command-config-prefixing-plugin.ts"() {
+    init_utils();
+  }
+});
+
+// src/lib/plugins/completion-detection.plugin.ts
+function completionDetectionPlugin({
+  onClose = true,
+  onExit = 50
+} = {}) {
+  function createEvents() {
+    let exitCode = -1;
+    const events = {
+      close: (0, import_promise_deferred.deferred)(),
+      closeTimeout: (0, import_promise_deferred.deferred)(),
+      exit: (0, import_promise_deferred.deferred)(),
+      exitTimeout: (0, import_promise_deferred.deferred)()
+    };
+    const result = Promise.race([
+      onClose === false ? never : events.closeTimeout.promise,
+      onExit === false ? never : events.exitTimeout.promise
+    ]);
+    configureTimeout(onClose, events.close, events.closeTimeout);
+    configureTimeout(onExit, events.exit, events.exitTimeout);
+    return {
+      close(code) {
+        exitCode = code;
+        events.close.done();
+      },
+      exit(code) {
+        exitCode = code;
+        events.exit.done();
+      },
+      get exitCode() {
+        return exitCode;
+      },
+      result
+    };
+  }
+  function configureTimeout(flag, event, timeout) {
+    if (flag === false) {
+      return;
+    }
+    (flag === true ? event.promise : event.promise.then(() => delay(flag))).then(timeout.done);
+  }
+  return {
+    type: "spawn.after",
+    action(_0, _1) {
+      return __async(this, arguments, function* (_data, { spawned, close }) {
+        var _a2, _b;
+        const events = createEvents();
+        let deferClose = true;
+        let quickClose = () => void (deferClose = false);
+        (_a2 = spawned.stdout) == null ? void 0 : _a2.on("data", quickClose);
+        (_b = spawned.stderr) == null ? void 0 : _b.on("data", quickClose);
+        spawned.on("error", quickClose);
+        spawned.on("close", (code) => events.close(code));
+        spawned.on("exit", (code) => events.exit(code));
+        try {
+          yield events.result;
+          if (deferClose) {
+            yield delay(50);
+          }
+          close(events.exitCode);
+        } catch (err) {
+          close(events.exitCode, err);
+        }
+      });
+    }
+  };
+}
+var import_promise_deferred, never;
+var init_completion_detection_plugin = __esm({
+  "src/lib/plugins/completion-detection.plugin.ts"() {
+    import_promise_deferred = __nccwpck_require__(7613);
+    init_utils();
+    never = (0, import_promise_deferred.deferred)().promise;
+  }
+});
+
+// src/lib/plugins/error-detection.plugin.ts
+function isTaskError(result) {
+  return !!(result.exitCode && result.stdErr.length);
+}
+function getErrorMessage(result) {
+  return Buffer.concat([...result.stdOut, ...result.stdErr]);
+}
+function errorDetectionHandler(overwrite = false, isError = isTaskError, errorMessage = getErrorMessage) {
+  return (error, result) => {
+    if (!overwrite && error || !isError(result)) {
+      return error;
+    }
+    return errorMessage(result);
+  };
+}
+function errorDetectionPlugin(config) {
+  return {
+    type: "task.error",
+    action(data, context) {
+      const error = config(data.error, {
+        stdErr: context.stdErr,
+        stdOut: context.stdOut,
+        exitCode: context.exitCode
+      });
+      if (Buffer.isBuffer(error)) {
+        return { error: new GitError(void 0, error.toString("utf-8")) };
+      }
+      return {
+        error
+      };
+    }
+  };
+}
+var init_error_detection_plugin = __esm({
+  "src/lib/plugins/error-detection.plugin.ts"() {
+    init_git_error();
+  }
+});
+
+// src/lib/plugins/plugin-store.ts
+var PluginStore;
+var init_plugin_store = __esm({
+  "src/lib/plugins/plugin-store.ts"() {
+    init_utils();
+    PluginStore = class {
+      constructor() {
+        this.plugins = /* @__PURE__ */ new Set();
+      }
+      add(plugin) {
+        const plugins = [];
+        asArray(plugin).forEach((plugin2) => plugin2 && this.plugins.add(append(plugins, plugin2)));
+        return () => {
+          plugins.forEach((plugin2) => this.plugins.delete(plugin2));
+        };
+      }
+      exec(type, data, context) {
+        let output = data;
+        const contextual = Object.freeze(Object.create(context));
+        for (const plugin of this.plugins) {
+          if (plugin.type === type) {
+            output = plugin.action(output, contextual);
+          }
+        }
+        return output;
+      }
+    };
+  }
+});
+
+// src/lib/plugins/progress-monitor-plugin.ts
+function progressMonitorPlugin(progress) {
+  const progressCommand = "--progress";
+  const progressMethods = ["checkout", "clone", "fetch", "pull", "push"];
+  const onProgress = {
+    type: "spawn.after",
+    action(_data, context) {
+      var _a2;
+      if (!context.commands.includes(progressCommand)) {
+        return;
+      }
+      (_a2 = context.spawned.stderr) == null ? void 0 : _a2.on("data", (chunk) => {
+        const message = /^([\s\S]+?):\s*(\d+)% \((\d+)\/(\d+)\)/.exec(chunk.toString("utf8"));
+        if (!message) {
+          return;
+        }
+        progress({
+          method: context.method,
+          stage: progressEventStage(message[1]),
+          progress: asNumber(message[2]),
+          processed: asNumber(message[3]),
+          total: asNumber(message[4])
+        });
+      });
+    }
+  };
+  const onArgs = {
+    type: "spawn.args",
+    action(args, context) {
+      if (!progressMethods.includes(context.method)) {
+        return args;
+      }
+      return including(args, progressCommand);
+    }
+  };
+  return [onArgs, onProgress];
+}
+function progressEventStage(input) {
+  return String(input.toLowerCase().split(" ", 1)) || "unknown";
+}
+var init_progress_monitor_plugin = __esm({
+  "src/lib/plugins/progress-monitor-plugin.ts"() {
+    init_utils();
+  }
+});
+
+// src/lib/plugins/simple-git-plugin.ts
+var init_simple_git_plugin = __esm({
+  "src/lib/plugins/simple-git-plugin.ts"() {
+  }
+});
+
+// src/lib/plugins/spawn-options-plugin.ts
+function spawnOptionsPlugin(spawnOptions) {
+  const options = pick(spawnOptions, ["uid", "gid"]);
+  return {
+    type: "spawn.options",
+    action(data) {
+      return __spreadValues(__spreadValues({}, options), data);
+    }
+  };
+}
+var init_spawn_options_plugin = __esm({
+  "src/lib/plugins/spawn-options-plugin.ts"() {
+    init_utils();
+  }
+});
+
+// src/lib/plugins/timout-plugin.ts
+function timeoutPlugin({
+  block,
+  stdErr = true,
+  stdOut = true
+}) {
+  if (block > 0) {
+    return {
+      type: "spawn.after",
+      action(_data, context) {
+        var _a2, _b;
+        let timeout;
+        function wait() {
+          timeout && clearTimeout(timeout);
+          timeout = setTimeout(kill, block);
+        }
+        function stop() {
+          var _a3, _b2;
+          (_a3 = context.spawned.stdout) == null ? void 0 : _a3.off("data", wait);
+          (_b2 = context.spawned.stderr) == null ? void 0 : _b2.off("data", wait);
+          context.spawned.off("exit", stop);
+          context.spawned.off("close", stop);
+          timeout && clearTimeout(timeout);
+        }
+        function kill() {
+          stop();
+          context.kill(new GitPluginError(void 0, "timeout", `block timeout reached`));
+        }
+        stdOut && ((_a2 = context.spawned.stdout) == null ? void 0 : _a2.on("data", wait));
+        stdErr && ((_b = context.spawned.stderr) == null ? void 0 : _b.on("data", wait));
+        context.spawned.on("exit", stop);
+        context.spawned.on("close", stop);
+        wait();
+      }
+    };
+  }
+}
+var init_timout_plugin = __esm({
+  "src/lib/plugins/timout-plugin.ts"() {
+    init_git_plugin_error();
+  }
+});
+
+// src/lib/plugins/index.ts
+var init_plugins = __esm({
+  "src/lib/plugins/index.ts"() {
+    init_abort_plugin();
+    init_block_unsafe_operations_plugin();
+    init_command_config_prefixing_plugin();
+    init_completion_detection_plugin();
+    init_error_detection_plugin();
+    init_plugin_store();
+    init_progress_monitor_plugin();
+    init_simple_git_plugin();
+    init_spawn_options_plugin();
+    init_timout_plugin();
+  }
+});
+
+// src/lib/git-logger.ts
+function createLog() {
+  return (0, import_debug.default)("simple-git");
+}
+function prefixedLogger(to, prefix, forward) {
+  if (!prefix || !String(prefix).replace(/\s*/, "")) {
+    return !forward ? to : (message, ...args) => {
+      to(message, ...args);
+      forward(message, ...args);
+    };
+  }
+  return (message, ...args) => {
+    to(`%s ${message}`, prefix, ...args);
+    if (forward) {
+      forward(message, ...args);
+    }
+  };
+}
+function childLoggerName(name, childDebugger, { namespace: parentNamespace }) {
+  if (typeof name === "string") {
+    return name;
+  }
+  const childNamespace = childDebugger && childDebugger.namespace || "";
+  if (childNamespace.startsWith(parentNamespace)) {
+    return childNamespace.substr(parentNamespace.length + 1);
+  }
+  return childNamespace || parentNamespace;
+}
+function createLogger(label, verbose, initialStep, infoDebugger = createLog()) {
+  const labelPrefix = label && `[${label}]` || "";
+  const spawned = [];
+  const debugDebugger = typeof verbose === "string" ? infoDebugger.extend(verbose) : verbose;
+  const key = childLoggerName(filterType(verbose, filterString), debugDebugger, infoDebugger);
+  return step(initialStep);
+  function sibling(name, initial) {
+    return append(spawned, createLogger(label, key.replace(/^[^:]+/, name), initial, infoDebugger));
+  }
+  function step(phase) {
+    const stepPrefix = phase && `[${phase}]` || "";
+    const debug2 = debugDebugger && prefixedLogger(debugDebugger, stepPrefix) || NOOP;
+    const info = prefixedLogger(infoDebugger, `${labelPrefix} ${stepPrefix}`, debug2);
+    return Object.assign(debugDebugger ? debug2 : info, {
+      label,
+      sibling,
+      info,
+      step
+    });
+  }
+}
+var import_debug;
+var init_git_logger = __esm({
+  "src/lib/git-logger.ts"() {
+    import_debug = __toESM(__nccwpck_require__(8237));
+    init_utils();
+    import_debug.default.formatters.L = (value) => String(filterHasLength(value) ? value.length : "-");
+    import_debug.default.formatters.B = (value) => {
+      if (Buffer.isBuffer(value)) {
+        return value.toString("utf8");
+      }
+      return objectToString(value);
+    };
+  }
+});
+
+// src/lib/runners/tasks-pending-queue.ts
+var _TasksPendingQueue, TasksPendingQueue;
+var init_tasks_pending_queue = __esm({
+  "src/lib/runners/tasks-pending-queue.ts"() {
+    init_git_error();
+    init_git_logger();
+    _TasksPendingQueue = class {
+      constructor(logLabel = "GitExecutor") {
+        this.logLabel = logLabel;
+        this._queue = /* @__PURE__ */ new Map();
+      }
+      withProgress(task) {
+        return this._queue.get(task);
+      }
+      createProgress(task) {
+        const name = _TasksPendingQueue.getName(task.commands[0]);
+        const logger = createLogger(this.logLabel, name);
+        return {
+          task,
+          logger,
+          name
+        };
+      }
+      push(task) {
+        const progress = this.createProgress(task);
+        progress.logger("Adding task to the queue, commands = %o", task.commands);
+        this._queue.set(task, progress);
+        return progress;
+      }
+      fatal(err) {
+        for (const [task, { logger }] of Array.from(this._queue.entries())) {
+          if (task === err.task) {
+            logger.info(`Failed %o`, err);
+            logger(`Fatal exception, any as-yet un-started tasks run through this executor will not be attempted`);
+          } else {
+            logger.info(`A fatal exception occurred in a previous task, the queue has been purged: %o`, err.message);
+          }
+          this.complete(task);
+        }
+        if (this._queue.size !== 0) {
+          throw new Error(`Queue size should be zero after fatal: ${this._queue.size}`);
+        }
+      }
+      complete(task) {
+        const progress = this.withProgress(task);
+        if (progress) {
+          this._queue.delete(task);
+        }
+      }
+      attempt(task) {
+        const progress = this.withProgress(task);
+        if (!progress) {
+          throw new GitError(void 0, "TasksPendingQueue: attempt called for an unknown task");
+        }
+        progress.logger("Starting task");
+        return progress;
+      }
+      static getName(name = "empty") {
+        return `task:${name}:${++_TasksPendingQueue.counter}`;
+      }
+    };
+    TasksPendingQueue = _TasksPendingQueue;
+    TasksPendingQueue.counter = 0;
+  }
+});
+
+// src/lib/runners/git-executor-chain.ts
+function pluginContext(task, commands) {
+  return {
+    method: first(task.commands) || "",
+    commands
+  };
+}
+function onErrorReceived(target, logger) {
+  return (err) => {
+    logger(`[ERROR] child process exception %o`, err);
+    target.push(Buffer.from(String(err.stack), "ascii"));
+  };
+}
+function onDataReceived(target, name, logger, output) {
+  return (buffer) => {
+    logger(`%s received %L bytes`, name, buffer);
+    output(`%B`, buffer);
+    target.push(buffer);
+  };
+}
+var import_child_process, GitExecutorChain;
+var init_git_executor_chain = __esm({
+  "src/lib/runners/git-executor-chain.ts"() {
+    import_child_process = __nccwpck_require__(2081);
+    init_git_error();
+    init_task();
+    init_utils();
+    init_tasks_pending_queue();
+    GitExecutorChain = class {
+      constructor(_executor, _scheduler, _plugins) {
+        this._executor = _executor;
+        this._scheduler = _scheduler;
+        this._plugins = _plugins;
+        this._chain = Promise.resolve();
+        this._queue = new TasksPendingQueue();
+      }
+      get binary() {
+        return this._executor.binary;
+      }
+      get cwd() {
+        return this._cwd || this._executor.cwd;
+      }
+      set cwd(cwd) {
+        this._cwd = cwd;
+      }
+      get env() {
+        return this._executor.env;
+      }
+      get outputHandler() {
+        return this._executor.outputHandler;
+      }
+      chain() {
+        return this;
+      }
+      push(task) {
+        this._queue.push(task);
+        return this._chain = this._chain.then(() => this.attemptTask(task));
+      }
+      attemptTask(task) {
+        return __async(this, null, function* () {
+          const onScheduleComplete = yield this._scheduler.next();
+          const onQueueComplete = () => this._queue.complete(task);
+          try {
+            const { logger } = this._queue.attempt(task);
+            return yield isEmptyTask(task) ? this.attemptEmptyTask(task, logger) : this.attemptRemoteTask(task, logger);
+          } catch (e) {
+            throw this.onFatalException(task, e);
+          } finally {
+            onQueueComplete();
+            onScheduleComplete();
+          }
+        });
+      }
+      onFatalException(task, e) {
+        const gitError = e instanceof GitError ? Object.assign(e, { task }) : new GitError(task, e && String(e));
+        this._chain = Promise.resolve();
+        this._queue.fatal(gitError);
+        return gitError;
+      }
+      attemptRemoteTask(task, logger) {
+        return __async(this, null, function* () {
+          const args = this._plugins.exec("spawn.args", [...task.commands], pluginContext(task, task.commands));
+          const raw = yield this.gitResponse(task, this.binary, args, this.outputHandler, logger.step("SPAWN"));
+          const outputStreams = yield this.handleTaskData(task, args, raw, logger.step("HANDLE"));
+          logger(`passing response to task's parser as a %s`, task.format);
+          if (isBufferTask(task)) {
+            return callTaskParser(task.parser, outputStreams);
+          }
+          return callTaskParser(task.parser, outputStreams.asStrings());
+        });
+      }
+      attemptEmptyTask(task, logger) {
+        return __async(this, null, function* () {
+          logger(`empty task bypassing child process to call to task's parser`);
+          return task.parser(this);
+        });
+      }
+      handleTaskData(task, args, result, logger) {
+        const { exitCode, rejection, stdOut, stdErr } = result;
+        return new Promise((done, fail) => {
+          logger(`Preparing to handle process response exitCode=%d stdOut=`, exitCode);
+          const { error } = this._plugins.exec("task.error", { error: rejection }, __spreadValues(__spreadValues({}, pluginContext(task, args)), result));
+          if (error && task.onError) {
+            logger.info(`exitCode=%s handling with custom error handler`);
+            return task.onError(result, error, (newStdOut) => {
+              logger.info(`custom error handler treated as success`);
+              logger(`custom error returned a %s`, objectToString(newStdOut));
+              done(new GitOutputStreams(Array.isArray(newStdOut) ? Buffer.concat(newStdOut) : newStdOut, Buffer.concat(stdErr)));
+            }, fail);
+          }
+          if (error) {
+            logger.info(`handling as error: exitCode=%s stdErr=%s rejection=%o`, exitCode, stdErr.length, rejection);
+            return fail(error);
+          }
+          logger.info(`retrieving task output complete`);
+          done(new GitOutputStreams(Buffer.concat(stdOut), Buffer.concat(stdErr)));
+        });
+      }
+      gitResponse(task, command, args, outputHandler, logger) {
+        return __async(this, null, function* () {
+          const outputLogger = logger.sibling("output");
+          const spawnOptions = this._plugins.exec("spawn.options", {
+            cwd: this.cwd,
+            env: this.env,
+            windowsHide: true
+          }, pluginContext(task, task.commands));
+          return new Promise((done) => {
+            const stdOut = [];
+            const stdErr = [];
+            logger.info(`%s %o`, command, args);
+            logger("%O", spawnOptions);
+            let rejection = this._beforeSpawn(task, args);
+            if (rejection) {
+              return done({
+                stdOut,
+                stdErr,
+                exitCode: 9901,
+                rejection
+              });
+            }
+            this._plugins.exec("spawn.before", void 0, __spreadProps(__spreadValues({}, pluginContext(task, args)), {
+              kill(reason) {
+                rejection = reason || rejection;
+              }
+            }));
+            const spawned = (0, import_child_process.spawn)(command, args, spawnOptions);
+            spawned.stdout.on("data", onDataReceived(stdOut, "stdOut", logger, outputLogger.step("stdOut")));
+            spawned.stderr.on("data", onDataReceived(stdErr, "stdErr", logger, outputLogger.step("stdErr")));
+            spawned.on("error", onErrorReceived(stdErr, logger));
+            if (outputHandler) {
+              logger(`Passing child process stdOut/stdErr to custom outputHandler`);
+              outputHandler(command, spawned.stdout, spawned.stderr, [...args]);
+            }
+            this._plugins.exec("spawn.after", void 0, __spreadProps(__spreadValues({}, pluginContext(task, args)), {
+              spawned,
+              close(exitCode, reason) {
+                done({
+                  stdOut,
+                  stdErr,
+                  exitCode,
+                  rejection: rejection || reason
+                });
+              },
+              kill(reason) {
+                if (spawned.killed) {
+                  return;
+                }
+                rejection = reason;
+                spawned.kill("SIGINT");
+              }
+            }));
+          });
+        });
+      }
+      _beforeSpawn(task, args) {
+        let rejection;
+        this._plugins.exec("spawn.before", void 0, __spreadProps(__spreadValues({}, pluginContext(task, args)), {
+          kill(reason) {
+            rejection = reason || rejection;
+          }
+        }));
+        return rejection;
+      }
+    };
+  }
+});
+
+// src/lib/runners/git-executor.ts
+var git_executor_exports = {};
+__export(git_executor_exports, {
+  GitExecutor: () => GitExecutor
+});
+var GitExecutor;
+var init_git_executor = __esm({
+  "src/lib/runners/git-executor.ts"() {
+    init_git_executor_chain();
+    GitExecutor = class {
+      constructor(binary = "git", cwd, _scheduler, _plugins) {
+        this.binary = binary;
+        this.cwd = cwd;
+        this._scheduler = _scheduler;
+        this._plugins = _plugins;
+        this._chain = new GitExecutorChain(this, this._scheduler, this._plugins);
+      }
+      chain() {
+        return new GitExecutorChain(this, this._scheduler, this._plugins);
+      }
+      push(task) {
+        return this._chain.push(task);
+      }
+    };
+  }
+});
+
+// src/lib/task-callback.ts
+function taskCallback(task, response, callback = NOOP) {
+  const onSuccess = (data) => {
+    callback(null, data);
+  };
+  const onError2 = (err) => {
+    if ((err == null ? void 0 : err.task) === task) {
+      callback(err instanceof GitResponseError ? addDeprecationNoticeToError(err) : err, void 0);
+    }
+  };
+  response.then(onSuccess, onError2);
+}
+function addDeprecationNoticeToError(err) {
+  let log = (name) => {
+    console.warn(`simple-git deprecation notice: accessing GitResponseError.${name} should be GitResponseError.git.${name}, this will no longer be available in version 3`);
+    log = NOOP;
+  };
+  return Object.create(err, Object.getOwnPropertyNames(err.git).reduce(descriptorReducer, {}));
+  function descriptorReducer(all, name) {
+    if (name in err) {
+      return all;
+    }
+    all[name] = {
+      enumerable: false,
+      configurable: false,
+      get() {
+        log(name);
+        return err.git[name];
+      }
+    };
+    return all;
+  }
+}
+var init_task_callback = __esm({
+  "src/lib/task-callback.ts"() {
+    init_git_response_error();
+    init_utils();
+  }
+});
+
+// src/lib/tasks/change-working-directory.ts
+function changeWorkingDirectoryTask(directory, root) {
+  return adhocExecTask((instance) => {
+    if (!folderExists(directory)) {
+      throw new Error(`Git.cwd: cannot change to non-directory "${directory}"`);
+    }
+    return (root || instance).cwd = directory;
+  });
+}
+var init_change_working_directory = __esm({
+  "src/lib/tasks/change-working-directory.ts"() {
+    init_utils();
+    init_task();
+  }
+});
+
+// src/lib/tasks/checkout.ts
+function checkoutTask(args) {
+  const commands = ["checkout", ...args];
+  if (commands[1] === "-b" && commands.includes("-B")) {
+    commands[1] = remove(commands, "-B");
+  }
+  return straightThroughStringTask(commands);
+}
+function checkout_default() {
+  return {
+    checkout() {
+      return this._runTask(checkoutTask(getTrailingOptions(arguments, 1)), trailingFunctionArgument(arguments));
+    },
+    checkoutBranch(branchName, startPoint) {
+      return this._runTask(checkoutTask(["-b", branchName, startPoint, ...getTrailingOptions(arguments)]), trailingFunctionArgument(arguments));
+    },
+    checkoutLocalBranch(branchName) {
+      return this._runTask(checkoutTask(["-b", branchName, ...getTrailingOptions(arguments)]), trailingFunctionArgument(arguments));
+    }
+  };
+}
+var init_checkout = __esm({
+  "src/lib/tasks/checkout.ts"() {
+    init_utils();
+    init_task();
+  }
+});
+
+// src/lib/parsers/parse-commit.ts
+function parseCommitResult(stdOut) {
+  const result = {
+    author: null,
+    branch: "",
+    commit: "",
+    root: false,
+    summary: {
+      changes: 0,
+      insertions: 0,
+      deletions: 0
+    }
+  };
+  return parseStringResponse(result, parsers, stdOut);
+}
+var parsers;
+var init_parse_commit = __esm({
+  "src/lib/parsers/parse-commit.ts"() {
+    init_utils();
+    parsers = [
+      new LineParser(/^\[([^\s]+)( \([^)]+\))? ([^\]]+)/, (result, [branch, root, commit]) => {
+        result.branch = branch;
+        result.commit = commit;
+        result.root = !!root;
+      }),
+      new LineParser(/\s*Author:\s(.+)/i, (result, [author]) => {
+        const parts = author.split("<");
+        const email = parts.pop();
+        if (!email || !email.includes("@")) {
+          return;
+        }
+        result.author = {
+          email: email.substr(0, email.length - 1),
+          name: parts.join("<").trim()
+        };
+      }),
+      new LineParser(/(\d+)[^,]*(?:,\s*(\d+)[^,]*)(?:,\s*(\d+))/g, (result, [changes, insertions, deletions]) => {
+        result.summary.changes = parseInt(changes, 10) || 0;
+        result.summary.insertions = parseInt(insertions, 10) || 0;
+        result.summary.deletions = parseInt(deletions, 10) || 0;
+      }),
+      new LineParser(/^(\d+)[^,]*(?:,\s*(\d+)[^(]+\(([+-]))?/, (result, [changes, lines, direction]) => {
+        result.summary.changes = parseInt(changes, 10) || 0;
+        const count = parseInt(lines, 10) || 0;
+        if (direction === "-") {
+          result.summary.deletions = count;
+        } else if (direction === "+") {
+          result.summary.insertions = count;
+        }
+      })
+    ];
+  }
+});
+
+// src/lib/tasks/commit.ts
+function commitTask(message, files, customArgs) {
+  const commands = [
+    "-c",
+    "core.abbrev=40",
+    "commit",
+    ...prefixedArray(message, "-m"),
+    ...files,
+    ...customArgs
+  ];
+  return {
+    commands,
+    format: "utf-8",
+    parser: parseCommitResult
+  };
+}
+function commit_default() {
+  return {
+    commit(message, ...rest) {
+      const next = trailingFunctionArgument(arguments);
+      const task = rejectDeprecatedSignatures(message) || commitTask(asArray(message), asArray(filterType(rest[0], filterStringOrStringArray, [])), [...filterType(rest[1], filterArray, []), ...getTrailingOptions(arguments, 0, true)]);
+      return this._runTask(task, next);
+    }
+  };
+  function rejectDeprecatedSignatures(message) {
+    return !filterStringOrStringArray(message) && configurationErrorTask(`git.commit: requires the commit message to be supplied as a string/string[]`);
+  }
+}
+var init_commit = __esm({
+  "src/lib/tasks/commit.ts"() {
+    init_parse_commit();
+    init_utils();
+    init_task();
+  }
+});
+
+// src/lib/tasks/hash-object.ts
+function hashObjectTask(filePath, write) {
+  const commands = ["hash-object", filePath];
+  if (write) {
+    commands.push("-w");
+  }
+  return straightThroughStringTask(commands, true);
+}
+var init_hash_object = __esm({
+  "src/lib/tasks/hash-object.ts"() {
+    init_task();
+  }
+});
+
+// src/lib/responses/InitSummary.ts
+function parseInit(bare, path, text) {
+  const response = String(text).trim();
+  let result;
+  if (result = initResponseRegex.exec(response)) {
+    return new InitSummary(bare, path, false, result[1]);
+  }
+  if (result = reInitResponseRegex.exec(response)) {
+    return new InitSummary(bare, path, true, result[1]);
+  }
+  let gitDir = "";
+  const tokens = response.split(" ");
+  while (tokens.length) {
+    const token = tokens.shift();
+    if (token === "in") {
+      gitDir = tokens.join(" ");
+      break;
+    }
+  }
+  return new InitSummary(bare, path, /^re/i.test(response), gitDir);
+}
+var InitSummary, initResponseRegex, reInitResponseRegex;
+var init_InitSummary = __esm({
+  "src/lib/responses/InitSummary.ts"() {
+    InitSummary = class {
+      constructor(bare, path, existing, gitDir) {
+        this.bare = bare;
+        this.path = path;
+        this.existing = existing;
+        this.gitDir = gitDir;
+      }
+    };
+    initResponseRegex = /^Init.+ repository in (.+)$/;
+    reInitResponseRegex = /^Rein.+ in (.+)$/;
+  }
+});
+
+// src/lib/tasks/init.ts
+function hasBareCommand(command) {
+  return command.includes(bareCommand);
+}
+function initTask(bare = false, path, customArgs) {
+  const commands = ["init", ...customArgs];
+  if (bare && !hasBareCommand(commands)) {
+    commands.splice(1, 0, bareCommand);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(text) {
+      return parseInit(commands.includes("--bare"), path, text);
+    }
+  };
+}
+var bareCommand;
+var init_init = __esm({
+  "src/lib/tasks/init.ts"() {
+    init_InitSummary();
+    bareCommand = "--bare";
+  }
+});
+
+// src/lib/args/log-format.ts
+function logFormatFromCommand(customArgs) {
+  for (let i = 0; i < customArgs.length; i++) {
+    const format = logFormatRegex.exec(customArgs[i]);
+    if (format) {
+      return `--${format[1]}`;
+    }
+  }
+  return "" /* NONE */;
+}
+function isLogFormat(customArg) {
+  return logFormatRegex.test(customArg);
+}
+var logFormatRegex;
+var init_log_format = __esm({
+  "src/lib/args/log-format.ts"() {
+    logFormatRegex = /^--(stat|numstat|name-only|name-status)(=|$)/;
+  }
+});
+
+// src/lib/responses/DiffSummary.ts
+var DiffSummary;
+var init_DiffSummary = __esm({
+  "src/lib/responses/DiffSummary.ts"() {
+    DiffSummary = class {
+      constructor() {
+        this.changed = 0;
+        this.deletions = 0;
+        this.insertions = 0;
+        this.files = [];
+      }
+    };
+  }
+});
+
+// src/lib/parsers/parse-diff-summary.ts
+function getDiffParser(format = "" /* NONE */) {
+  const parser3 = diffSummaryParsers[format];
+  return (stdOut) => parseStringResponse(new DiffSummary(), parser3, stdOut, false);
+}
+var statParser, numStatParser, nameOnlyParser, nameStatusParser, diffSummaryParsers;
+var init_parse_diff_summary = __esm({
+  "src/lib/parsers/parse-diff-summary.ts"() {
+    init_log_format();
+    init_DiffSummary();
+    init_utils();
+    statParser = [
+      new LineParser(/(.+)\s+\|\s+(\d+)(\s+[+\-]+)?$/, (result, [file, changes, alterations = ""]) => {
+        result.files.push({
+          file: file.trim(),
+          changes: asNumber(changes),
+          insertions: alterations.replace(/[^+]/g, "").length,
+          deletions: alterations.replace(/[^-]/g, "").length,
+          binary: false
+        });
+      }),
+      new LineParser(/(.+) \|\s+Bin ([0-9.]+) -> ([0-9.]+) ([a-z]+)/, (result, [file, before, after]) => {
+        result.files.push({
+          file: file.trim(),
+          before: asNumber(before),
+          after: asNumber(after),
+          binary: true
+        });
+      }),
+      new LineParser(/(\d+) files? changed\s*((?:, \d+ [^,]+){0,2})/, (result, [changed, summary]) => {
+        const inserted = /(\d+) i/.exec(summary);
+        const deleted = /(\d+) d/.exec(summary);
+        result.changed = asNumber(changed);
+        result.insertions = asNumber(inserted == null ? void 0 : inserted[1]);
+        result.deletions = asNumber(deleted == null ? void 0 : deleted[1]);
+      })
+    ];
+    numStatParser = [
+      new LineParser(/(\d+)\t(\d+)\t(.+)$/, (result, [changesInsert, changesDelete, file]) => {
+        const insertions = asNumber(changesInsert);
+        const deletions = asNumber(changesDelete);
+        result.changed++;
+        result.insertions += insertions;
+        result.deletions += deletions;
+        result.files.push({
+          file,
+          changes: insertions + deletions,
+          insertions,
+          deletions,
+          binary: false
+        });
+      }),
+      new LineParser(/-\t-\t(.+)$/, (result, [file]) => {
+        result.changed++;
+        result.files.push({
+          file,
+          after: 0,
+          before: 0,
+          binary: true
+        });
+      })
+    ];
+    nameOnlyParser = [
+      new LineParser(/(.+)$/, (result, [file]) => {
+        result.changed++;
+        result.files.push({
+          file,
+          changes: 0,
+          insertions: 0,
+          deletions: 0,
+          binary: false
+        });
+      })
+    ];
+    nameStatusParser = [
+      new LineParser(/([ACDMRTUXB])\s*(.+)$/, (result, [_status, file]) => {
+        result.changed++;
+        result.files.push({
+          file,
+          changes: 0,
+          insertions: 0,
+          deletions: 0,
+          binary: false
+        });
+      })
+    ];
+    diffSummaryParsers = {
+      ["" /* NONE */]: statParser,
+      ["--stat" /* STAT */]: statParser,
+      ["--numstat" /* NUM_STAT */]: numStatParser,
+      ["--name-status" /* NAME_STATUS */]: nameStatusParser,
+      ["--name-only" /* NAME_ONLY */]: nameOnlyParser
+    };
+  }
+});
+
+// src/lib/parsers/parse-list-log-summary.ts
+function lineBuilder(tokens, fields) {
+  return fields.reduce((line, field, index) => {
+    line[field] = tokens[index] || "";
+    return line;
+  }, /* @__PURE__ */ Object.create({ diff: null }));
+}
+function createListLogSummaryParser(splitter = SPLITTER, fields = defaultFieldNames, logFormat = "" /* NONE */) {
+  const parseDiffResult = getDiffParser(logFormat);
+  return function(stdOut) {
+    const all = toLinesWithContent(stdOut, true, START_BOUNDARY).map(function(item) {
+      const lineDetail = item.trim().split(COMMIT_BOUNDARY);
+      const listLogLine = lineBuilder(lineDetail[0].trim().split(splitter), fields);
+      if (lineDetail.length > 1 && !!lineDetail[1].trim()) {
+        listLogLine.diff = parseDiffResult(lineDetail[1]);
+      }
+      return listLogLine;
+    });
+    return {
+      all,
+      latest: all.length && all[0] || null,
+      total: all.length
+    };
+  };
+}
+var START_BOUNDARY, COMMIT_BOUNDARY, SPLITTER, defaultFieldNames;
+var init_parse_list_log_summary = __esm({
+  "src/lib/parsers/parse-list-log-summary.ts"() {
+    init_utils();
+    init_parse_diff_summary();
+    init_log_format();
+    START_BOUNDARY = "\xF2\xF2\xF2\xF2\xF2\xF2 ";
+    COMMIT_BOUNDARY = " \xF2\xF2";
+    SPLITTER = " \xF2 ";
+    defaultFieldNames = ["hash", "date", "message", "refs", "author_name", "author_email"];
+  }
+});
+
+// src/lib/tasks/diff.ts
+var diff_exports = {};
+__export(diff_exports, {
+  diffSummaryTask: () => diffSummaryTask,
+  validateLogFormatConfig: () => validateLogFormatConfig
+});
+function diffSummaryTask(customArgs) {
+  let logFormat = logFormatFromCommand(customArgs);
+  const commands = ["diff"];
+  if (logFormat === "" /* NONE */) {
+    logFormat = "--stat" /* STAT */;
+    commands.push("--stat=4096");
+  }
+  commands.push(...customArgs);
+  return validateLogFormatConfig(commands) || {
+    commands,
+    format: "utf-8",
+    parser: getDiffParser(logFormat)
+  };
+}
+function validateLogFormatConfig(customArgs) {
+  const flags = customArgs.filter(isLogFormat);
+  if (flags.length > 1) {
+    return configurationErrorTask(`Summary flags are mutually exclusive - pick one of ${flags.join(",")}`);
+  }
+  if (flags.length && customArgs.includes("-z")) {
+    return configurationErrorTask(`Summary flag ${flags} parsing is not compatible with null termination option '-z'`);
+  }
+}
+var init_diff = __esm({
+  "src/lib/tasks/diff.ts"() {
+    init_log_format();
+    init_parse_diff_summary();
+    init_task();
+  }
+});
+
+// src/lib/tasks/log.ts
+function prettyFormat(format, splitter) {
+  const fields = [];
+  const formatStr = [];
+  Object.keys(format).forEach((field) => {
+    fields.push(field);
+    formatStr.push(String(format[field]));
+  });
+  return [fields, formatStr.join(splitter)];
+}
+function userOptions(input) {
+  return Object.keys(input).reduce((out, key) => {
+    if (!(key in excludeOptions)) {
+      out[key] = input[key];
+    }
+    return out;
+  }, {});
+}
+function parseLogOptions(opt = {}, customArgs = []) {
+  const splitter = filterType(opt.splitter, filterString, SPLITTER);
+  const format = !filterPrimitives(opt.format) && opt.format ? opt.format : {
+    hash: "%H",
+    date: opt.strictDate === false ? "%ai" : "%aI",
+    message: "%s",
+    refs: "%D",
+    body: opt.multiLine ? "%B" : "%b",
+    author_name: opt.mailMap !== false ? "%aN" : "%an",
+    author_email: opt.mailMap !== false ? "%aE" : "%ae"
+  };
+  const [fields, formatStr] = prettyFormat(format, splitter);
+  const suffix = [];
+  const command = [
+    `--pretty=format:${START_BOUNDARY}${formatStr}${COMMIT_BOUNDARY}`,
+    ...customArgs
+  ];
+  const maxCount = opt.n || opt["max-count"] || opt.maxCount;
+  if (maxCount) {
+    command.push(`--max-count=${maxCount}`);
+  }
+  if (opt.from || opt.to) {
+    const rangeOperator = opt.symmetric !== false ? "..." : "..";
+    suffix.push(`${opt.from || ""}${rangeOperator}${opt.to || ""}`);
+  }
+  if (filterString(opt.file)) {
+    suffix.push("--follow", opt.file);
+  }
+  appendTaskOptions(userOptions(opt), command);
+  return {
+    fields,
+    splitter,
+    commands: [...command, ...suffix]
+  };
+}
+function logTask(splitter, fields, customArgs) {
+  const parser3 = createListLogSummaryParser(splitter, fields, logFormatFromCommand(customArgs));
+  return {
+    commands: ["log", ...customArgs],
+    format: "utf-8",
+    parser: parser3
+  };
+}
+function log_default() {
+  return {
+    log(...rest) {
+      const next = trailingFunctionArgument(arguments);
+      const options = parseLogOptions(trailingOptionsArgument(arguments), filterType(arguments[0], filterArray));
+      const task = rejectDeprecatedSignatures(...rest) || validateLogFormatConfig(options.commands) || createLogTask(options);
+      return this._runTask(task, next);
+    }
+  };
+  function createLogTask(options) {
+    return logTask(options.splitter, options.fields, options.commands);
+  }
+  function rejectDeprecatedSignatures(from, to) {
+    return filterString(from) && filterString(to) && configurationErrorTask(`git.log(string, string) should be replaced with git.log({ from: string, to: string })`);
+  }
+}
+var excludeOptions;
+var init_log = __esm({
+  "src/lib/tasks/log.ts"() {
+    init_log_format();
+    init_parse_list_log_summary();
+    init_utils();
+    init_task();
+    init_diff();
+    excludeOptions = /* @__PURE__ */ ((excludeOptions2) => {
+      excludeOptions2[excludeOptions2["--pretty"] = 0] = "--pretty";
+      excludeOptions2[excludeOptions2["max-count"] = 1] = "max-count";
+      excludeOptions2[excludeOptions2["maxCount"] = 2] = "maxCount";
+      excludeOptions2[excludeOptions2["n"] = 3] = "n";
+      excludeOptions2[excludeOptions2["file"] = 4] = "file";
+      excludeOptions2[excludeOptions2["format"] = 5] = "format";
+      excludeOptions2[excludeOptions2["from"] = 6] = "from";
+      excludeOptions2[excludeOptions2["to"] = 7] = "to";
+      excludeOptions2[excludeOptions2["splitter"] = 8] = "splitter";
+      excludeOptions2[excludeOptions2["symmetric"] = 9] = "symmetric";
+      excludeOptions2[excludeOptions2["mailMap"] = 10] = "mailMap";
+      excludeOptions2[excludeOptions2["multiLine"] = 11] = "multiLine";
+      excludeOptions2[excludeOptions2["strictDate"] = 12] = "strictDate";
+      return excludeOptions2;
+    })(excludeOptions || {});
+  }
+});
+
+// src/lib/responses/MergeSummary.ts
+var MergeSummaryConflict, MergeSummaryDetail;
+var init_MergeSummary = __esm({
+  "src/lib/responses/MergeSummary.ts"() {
+    MergeSummaryConflict = class {
+      constructor(reason, file = null, meta) {
+        this.reason = reason;
+        this.file = file;
+        this.meta = meta;
+      }
+      toString() {
+        return `${this.file}:${this.reason}`;
+      }
+    };
+    MergeSummaryDetail = class {
+      constructor() {
+        this.conflicts = [];
+        this.merges = [];
+        this.result = "success";
+      }
+      get failed() {
+        return this.conflicts.length > 0;
+      }
+      get reason() {
+        return this.result;
+      }
+      toString() {
+        if (this.conflicts.length) {
+          return `CONFLICTS: ${this.conflicts.join(", ")}`;
+        }
+        return "OK";
+      }
+    };
+  }
+});
+
+// src/lib/responses/PullSummary.ts
+var PullSummary, PullFailedSummary;
+var init_PullSummary = __esm({
+  "src/lib/responses/PullSummary.ts"() {
+    PullSummary = class {
+      constructor() {
+        this.remoteMessages = {
+          all: []
+        };
+        this.created = [];
+        this.deleted = [];
+        this.files = [];
+        this.deletions = {};
+        this.insertions = {};
+        this.summary = {
+          changes: 0,
+          deletions: 0,
+          insertions: 0
+        };
+      }
+    };
+    PullFailedSummary = class {
+      constructor() {
+        this.remote = "";
+        this.hash = {
+          local: "",
+          remote: ""
+        };
+        this.branch = {
+          local: "",
+          remote: ""
+        };
+        this.message = "";
+      }
+      toString() {
+        return this.message;
+      }
+    };
+  }
+});
+
+// src/lib/parsers/parse-remote-objects.ts
+function objectEnumerationResult(remoteMessages) {
+  return remoteMessages.objects = remoteMessages.objects || {
+    compressing: 0,
+    counting: 0,
+    enumerating: 0,
+    packReused: 0,
+    reused: { count: 0, delta: 0 },
+    total: { count: 0, delta: 0 }
+  };
+}
+function asObjectCount(source) {
+  const count = /^\s*(\d+)/.exec(source);
+  const delta = /delta (\d+)/i.exec(source);
+  return {
+    count: asNumber(count && count[1] || "0"),
+    delta: asNumber(delta && delta[1] || "0")
+  };
+}
+var remoteMessagesObjectParsers;
+var init_parse_remote_objects = __esm({
+  "src/lib/parsers/parse-remote-objects.ts"() {
+    init_utils();
+    remoteMessagesObjectParsers = [
+      new RemoteLineParser(/^remote:\s*(enumerating|counting|compressing) objects: (\d+),/i, (result, [action, count]) => {
+        const key = action.toLowerCase();
+        const enumeration = objectEnumerationResult(result.remoteMessages);
+        Object.assign(enumeration, { [key]: asNumber(count) });
+      }),
+      new RemoteLineParser(/^remote:\s*(enumerating|counting|compressing) objects: \d+% \(\d+\/(\d+)\),/i, (result, [action, count]) => {
+        const key = action.toLowerCase();
+        const enumeration = objectEnumerationResult(result.remoteMessages);
+        Object.assign(enumeration, { [key]: asNumber(count) });
+      }),
+      new RemoteLineParser(/total ([^,]+), reused ([^,]+), pack-reused (\d+)/i, (result, [total, reused, packReused]) => {
+        const objects = objectEnumerationResult(result.remoteMessages);
+        objects.total = asObjectCount(total);
+        objects.reused = asObjectCount(reused);
+        objects.packReused = asNumber(packReused);
+      })
+    ];
+  }
+});
+
+// src/lib/parsers/parse-remote-messages.ts
+function parseRemoteMessages(_stdOut, stdErr) {
+  return parseStringResponse({ remoteMessages: new RemoteMessageSummary() }, parsers2, stdErr);
+}
+var parsers2, RemoteMessageSummary;
+var init_parse_remote_messages = __esm({
+  "src/lib/parsers/parse-remote-messages.ts"() {
+    init_utils();
+    init_parse_remote_objects();
+    parsers2 = [
+      new RemoteLineParser(/^remote:\s*(.+)$/, (result, [text]) => {
+        result.remoteMessages.all.push(text.trim());
+        return false;
+      }),
+      ...remoteMessagesObjectParsers,
+      new RemoteLineParser([/create a (?:pull|merge) request/i, /\s(https?:\/\/\S+)$/], (result, [pullRequestUrl]) => {
+        result.remoteMessages.pullRequestUrl = pullRequestUrl;
+      }),
+      new RemoteLineParser([/found (\d+) vulnerabilities.+\(([^)]+)\)/i, /\s(https?:\/\/\S+)$/], (result, [count, summary, url]) => {
+        result.remoteMessages.vulnerabilities = {
+          count: asNumber(count),
+          summary,
+          url
+        };
+      })
+    ];
+    RemoteMessageSummary = class {
+      constructor() {
+        this.all = [];
+      }
+    };
+  }
+});
+
+// src/lib/parsers/parse-pull.ts
+function parsePullErrorResult(stdOut, stdErr) {
+  const pullError = parseStringResponse(new PullFailedSummary(), errorParsers, [stdOut, stdErr]);
+  return pullError.message && pullError;
+}
+var FILE_UPDATE_REGEX, SUMMARY_REGEX, ACTION_REGEX, parsers3, errorParsers, parsePullDetail, parsePullResult;
+var init_parse_pull = __esm({
+  "src/lib/parsers/parse-pull.ts"() {
+    init_PullSummary();
+    init_utils();
+    init_parse_remote_messages();
+    FILE_UPDATE_REGEX = /^\s*(.+?)\s+\|\s+\d+\s*(\+*)(-*)/;
+    SUMMARY_REGEX = /(\d+)\D+((\d+)\D+\(\+\))?(\D+(\d+)\D+\(-\))?/;
+    ACTION_REGEX = /^(create|delete) mode \d+ (.+)/;
+    parsers3 = [
+      new LineParser(FILE_UPDATE_REGEX, (result, [file, insertions, deletions]) => {
+        result.files.push(file);
+        if (insertions) {
+          result.insertions[file] = insertions.length;
+        }
+        if (deletions) {
+          result.deletions[file] = deletions.length;
+        }
+      }),
+      new LineParser(SUMMARY_REGEX, (result, [changes, , insertions, , deletions]) => {
+        if (insertions !== void 0 || deletions !== void 0) {
+          result.summary.changes = +changes || 0;
+          result.summary.insertions = +insertions || 0;
+          result.summary.deletions = +deletions || 0;
+          return true;
+        }
+        return false;
+      }),
+      new LineParser(ACTION_REGEX, (result, [action, file]) => {
+        append(result.files, file);
+        append(action === "create" ? result.created : result.deleted, file);
+      })
+    ];
+    errorParsers = [
+      new LineParser(/^from\s(.+)$/i, (result, [remote]) => void (result.remote = remote)),
+      new LineParser(/^fatal:\s(.+)$/, (result, [message]) => void (result.message = message)),
+      new LineParser(/([a-z0-9]+)\.\.([a-z0-9]+)\s+(\S+)\s+->\s+(\S+)$/, (result, [hashLocal, hashRemote, branchLocal, branchRemote]) => {
+        result.branch.local = branchLocal;
+        result.hash.local = hashLocal;
+        result.branch.remote = branchRemote;
+        result.hash.remote = hashRemote;
+      })
+    ];
+    parsePullDetail = (stdOut, stdErr) => {
+      return parseStringResponse(new PullSummary(), parsers3, [stdOut, stdErr]);
+    };
+    parsePullResult = (stdOut, stdErr) => {
+      return Object.assign(new PullSummary(), parsePullDetail(stdOut, stdErr), parseRemoteMessages(stdOut, stdErr));
+    };
+  }
+});
+
+// src/lib/parsers/parse-merge.ts
+var parsers4, parseMergeResult, parseMergeDetail;
+var init_parse_merge = __esm({
+  "src/lib/parsers/parse-merge.ts"() {
+    init_MergeSummary();
+    init_utils();
+    init_parse_pull();
+    parsers4 = [
+      new LineParser(/^Auto-merging\s+(.+)$/, (summary, [autoMerge]) => {
+        summary.merges.push(autoMerge);
+      }),
+      new LineParser(/^CONFLICT\s+\((.+)\): Merge conflict in (.+)$/, (summary, [reason, file]) => {
+        summary.conflicts.push(new MergeSummaryConflict(reason, file));
+      }),
+      new LineParser(/^CONFLICT\s+\((.+\/delete)\): (.+) deleted in (.+) and/, (summary, [reason, file, deleteRef]) => {
+        summary.conflicts.push(new MergeSummaryConflict(reason, file, { deleteRef }));
+      }),
+      new LineParser(/^CONFLICT\s+\((.+)\):/, (summary, [reason]) => {
+        summary.conflicts.push(new MergeSummaryConflict(reason, null));
+      }),
+      new LineParser(/^Automatic merge failed;\s+(.+)$/, (summary, [result]) => {
+        summary.result = result;
+      })
+    ];
+    parseMergeResult = (stdOut, stdErr) => {
+      return Object.assign(parseMergeDetail(stdOut, stdErr), parsePullResult(stdOut, stdErr));
+    };
+    parseMergeDetail = (stdOut) => {
+      return parseStringResponse(new MergeSummaryDetail(), parsers4, stdOut);
+    };
+  }
+});
+
+// src/lib/tasks/merge.ts
+function mergeTask(customArgs) {
+  if (!customArgs.length) {
+    return configurationErrorTask("Git.merge requires at least one option");
+  }
+  return {
+    commands: ["merge", ...customArgs],
+    format: "utf-8",
+    parser(stdOut, stdErr) {
+      const merge = parseMergeResult(stdOut, stdErr);
+      if (merge.failed) {
+        throw new GitResponseError(merge);
+      }
+      return merge;
+    }
+  };
+}
+var init_merge = __esm({
+  "src/lib/tasks/merge.ts"() {
+    init_git_response_error();
+    init_parse_merge();
+    init_task();
+  }
+});
+
+// src/lib/parsers/parse-push.ts
+function pushResultPushedItem(local, remote, status) {
+  const deleted = status.includes("deleted");
+  const tag = status.includes("tag") || /^refs\/tags/.test(local);
+  const alreadyUpdated = !status.includes("new");
+  return {
+    deleted,
+    tag,
+    branch: !tag,
+    new: !alreadyUpdated,
+    alreadyUpdated,
+    local,
+    remote
+  };
+}
+var parsers5, parsePushResult, parsePushDetail;
+var init_parse_push = __esm({
+  "src/lib/parsers/parse-push.ts"() {
+    init_utils();
+    init_parse_remote_messages();
+    parsers5 = [
+      new LineParser(/^Pushing to (.+)$/, (result, [repo]) => {
+        result.repo = repo;
+      }),
+      new LineParser(/^updating local tracking ref '(.+)'/, (result, [local]) => {
+        result.ref = __spreadProps(__spreadValues({}, result.ref || {}), {
+          local
+        });
+      }),
+      new LineParser(/^[=*-]\s+([^:]+):(\S+)\s+\[(.+)]$/, (result, [local, remote, type]) => {
+        result.pushed.push(pushResultPushedItem(local, remote, type));
+      }),
+      new LineParser(/^Branch '([^']+)' set up to track remote branch '([^']+)' from '([^']+)'/, (result, [local, remote, remoteName]) => {
+        result.branch = __spreadProps(__spreadValues({}, result.branch || {}), {
+          local,
+          remote,
+          remoteName
+        });
+      }),
+      new LineParser(/^([^:]+):(\S+)\s+([a-z0-9]+)\.\.([a-z0-9]+)$/, (result, [local, remote, from, to]) => {
+        result.update = {
+          head: {
+            local,
+            remote
+          },
+          hash: {
+            from,
+            to
+          }
+        };
+      })
+    ];
+    parsePushResult = (stdOut, stdErr) => {
+      const pushDetail = parsePushDetail(stdOut, stdErr);
+      const responseDetail = parseRemoteMessages(stdOut, stdErr);
+      return __spreadValues(__spreadValues({}, pushDetail), responseDetail);
+    };
+    parsePushDetail = (stdOut, stdErr) => {
+      return parseStringResponse({ pushed: [] }, parsers5, [stdOut, stdErr]);
+    };
+  }
+});
+
+// src/lib/tasks/push.ts
+var push_exports = {};
+__export(push_exports, {
+  pushTagsTask: () => pushTagsTask,
+  pushTask: () => pushTask
+});
+function pushTagsTask(ref = {}, customArgs) {
+  append(customArgs, "--tags");
+  return pushTask(ref, customArgs);
+}
+function pushTask(ref = {}, customArgs) {
+  const commands = ["push", ...customArgs];
+  if (ref.branch) {
+    commands.splice(1, 0, ref.branch);
+  }
+  if (ref.remote) {
+    commands.splice(1, 0, ref.remote);
+  }
+  remove(commands, "-v");
+  append(commands, "--verbose");
+  append(commands, "--porcelain");
+  return {
+    commands,
+    format: "utf-8",
+    parser: parsePushResult
+  };
+}
+var init_push = __esm({
+  "src/lib/tasks/push.ts"() {
+    init_parse_push();
+    init_utils();
+  }
+});
+
+// src/lib/responses/FileStatusSummary.ts
+var fromPathRegex, FileStatusSummary;
+var init_FileStatusSummary = __esm({
+  "src/lib/responses/FileStatusSummary.ts"() {
+    fromPathRegex = /^(.+) -> (.+)$/;
+    FileStatusSummary = class {
+      constructor(path, index, working_dir) {
+        this.path = path;
+        this.index = index;
+        this.working_dir = working_dir;
+        if (index + working_dir === "R") {
+          const detail = fromPathRegex.exec(path) || [null, path, path];
+          this.from = detail[1] || "";
+          this.path = detail[2] || "";
+        }
+      }
+    };
+  }
+});
+
+// src/lib/responses/StatusSummary.ts
+function renamedFile(line) {
+  const [to, from] = line.split(NULL);
+  return {
+    from: from || to,
+    to
+  };
+}
+function parser2(indexX, indexY, handler) {
+  return [`${indexX}${indexY}`, handler];
+}
+function conflicts(indexX, ...indexY) {
+  return indexY.map((y) => parser2(indexX, y, (result, file) => append(result.conflicted, file)));
+}
+function splitLine(result, lineStr) {
+  const trimmed2 = lineStr.trim();
+  switch (" ") {
+    case trimmed2.charAt(2):
+      return data(trimmed2.charAt(0), trimmed2.charAt(1), trimmed2.substr(3));
+    case trimmed2.charAt(1):
+      return data(" " /* NONE */, trimmed2.charAt(0), trimmed2.substr(2));
+    default:
+      return;
+  }
+  function data(index, workingDir, path) {
+    const raw = `${index}${workingDir}`;
+    const handler = parsers6.get(raw);
+    if (handler) {
+      handler(result, path);
+    }
+    if (raw !== "##" && raw !== "!!") {
+      result.files.push(new FileStatusSummary(path.replace(/\0.+$/, ""), index, workingDir));
+    }
+  }
+}
+var StatusSummary, parsers6, parseStatusSummary;
+var init_StatusSummary = __esm({
+  "src/lib/responses/StatusSummary.ts"() {
+    init_utils();
+    init_FileStatusSummary();
+    StatusSummary = class {
+      constructor() {
+        this.not_added = [];
+        this.conflicted = [];
+        this.created = [];
+        this.deleted = [];
+        this.ignored = void 0;
+        this.modified = [];
+        this.renamed = [];
+        this.files = [];
+        this.staged = [];
+        this.ahead = 0;
+        this.behind = 0;
+        this.current = null;
+        this.tracking = null;
+        this.detached = false;
+        this.isClean = () => {
+          return !this.files.length;
+        };
+      }
+    };
+    parsers6 = new Map([
+      parser2(" " /* NONE */, "A" /* ADDED */, (result, file) => append(result.created, file)),
+      parser2(" " /* NONE */, "D" /* DELETED */, (result, file) => append(result.deleted, file)),
+      parser2(" " /* NONE */, "M" /* MODIFIED */, (result, file) => append(result.modified, file)),
+      parser2("A" /* ADDED */, " " /* NONE */, (result, file) => append(result.created, file) && append(result.staged, file)),
+      parser2("A" /* ADDED */, "M" /* MODIFIED */, (result, file) => append(result.created, file) && append(result.staged, file) && append(result.modified, file)),
+      parser2("D" /* DELETED */, " " /* NONE */, (result, file) => append(result.deleted, file) && append(result.staged, file)),
+      parser2("M" /* MODIFIED */, " " /* NONE */, (result, file) => append(result.modified, file) && append(result.staged, file)),
+      parser2("M" /* MODIFIED */, "M" /* MODIFIED */, (result, file) => append(result.modified, file) && append(result.staged, file)),
+      parser2("R" /* RENAMED */, " " /* NONE */, (result, file) => {
+        append(result.renamed, renamedFile(file));
+      }),
+      parser2("R" /* RENAMED */, "M" /* MODIFIED */, (result, file) => {
+        const renamed = renamedFile(file);
+        append(result.renamed, renamed);
+        append(result.modified, renamed.to);
+      }),
+      parser2("!" /* IGNORED */, "!" /* IGNORED */, (_result, _file) => {
+        append(_result.ignored = _result.ignored || [], _file);
+      }),
+      parser2("?" /* UNTRACKED */, "?" /* UNTRACKED */, (result, file) => append(result.not_added, file)),
+      ...conflicts("A" /* ADDED */, "A" /* ADDED */, "U" /* UNMERGED */),
+      ...conflicts("D" /* DELETED */, "D" /* DELETED */, "U" /* UNMERGED */),
+      ...conflicts("U" /* UNMERGED */, "A" /* ADDED */, "D" /* DELETED */, "U" /* UNMERGED */),
+      [
+        "##",
+        (result, line) => {
+          const aheadReg = /ahead (\d+)/;
+          const behindReg = /behind (\d+)/;
+          const currentReg = /^(.+?(?=(?:\.{3}|\s|$)))/;
+          const trackingReg = /\.{3}(\S*)/;
+          const onEmptyBranchReg = /\son\s([\S]+)$/;
+          let regexResult;
+          regexResult = aheadReg.exec(line);
+          result.ahead = regexResult && +regexResult[1] || 0;
+          regexResult = behindReg.exec(line);
+          result.behind = regexResult && +regexResult[1] || 0;
+          regexResult = currentReg.exec(line);
+          result.current = regexResult && regexResult[1];
+          regexResult = trackingReg.exec(line);
+          result.tracking = regexResult && regexResult[1];
+          regexResult = onEmptyBranchReg.exec(line);
+          result.current = regexResult && regexResult[1] || result.current;
+          result.detached = /\(no branch\)/.test(line);
+        }
+      ]
+    ]);
+    parseStatusSummary = function(text) {
+      const lines = text.split(NULL);
+      const status = new StatusSummary();
+      for (let i = 0, l = lines.length; i < l; ) {
+        let line = lines[i++].trim();
+        if (!line) {
+          continue;
+        }
+        if (line.charAt(0) === "R" /* RENAMED */) {
+          line += NULL + (lines[i++] || "");
+        }
+        splitLine(status, line);
+      }
+      return status;
+    };
+  }
+});
+
+// src/lib/tasks/status.ts
+function statusTask(customArgs) {
+  const commands = [
+    "status",
+    "--porcelain",
+    "-b",
+    "-u",
+    "--null",
+    ...customArgs.filter((arg) => !ignoredOptions.includes(arg))
+  ];
+  return {
+    format: "utf-8",
+    commands,
+    parser(text) {
+      return parseStatusSummary(text);
+    }
+  };
+}
+var ignoredOptions;
+var init_status = __esm({
+  "src/lib/tasks/status.ts"() {
+    init_StatusSummary();
+    ignoredOptions = ["--null", "-z"];
+  }
+});
+
+// src/lib/tasks/version.ts
+function versionResponse(major = 0, minor = 0, patch = 0, agent = "", installed = true) {
+  return Object.defineProperty({
+    major,
+    minor,
+    patch,
+    agent,
+    installed
+  }, "toString", {
+    value() {
+      return `${this.major}.${this.minor}.${this.patch}`;
+    },
+    configurable: false,
+    enumerable: false
+  });
+}
+function notInstalledResponse() {
+  return versionResponse(0, 0, 0, "", false);
+}
+function version_default() {
+  return {
+    version() {
+      return this._runTask({
+        commands: ["--version"],
+        format: "utf-8",
+        parser: versionParser,
+        onError(result, error, done, fail) {
+          if (result.exitCode === -2 /* NOT_FOUND */) {
+            return done(Buffer.from(NOT_INSTALLED));
+          }
+          fail(error);
+        }
+      });
+    }
+  };
+}
+function versionParser(stdOut) {
+  if (stdOut === NOT_INSTALLED) {
+    return notInstalledResponse();
+  }
+  return parseStringResponse(versionResponse(0, 0, 0, stdOut), parsers7, stdOut);
+}
+var NOT_INSTALLED, parsers7;
+var init_version = __esm({
+  "src/lib/tasks/version.ts"() {
+    init_utils();
+    NOT_INSTALLED = "installed=false";
+    parsers7 = [
+      new LineParser(/version (\d+)\.(\d+)\.(\d+)(?:\s*\((.+)\))?/, (result, [major, minor, patch, agent = ""]) => {
+        Object.assign(result, versionResponse(asNumber(major), asNumber(minor), asNumber(patch), agent));
+      }),
+      new LineParser(/version (\d+)\.(\d+)\.(\D+)(.+)?$/, (result, [major, minor, patch, agent = ""]) => {
+        Object.assign(result, versionResponse(asNumber(major), asNumber(minor), patch, agent));
+      })
+    ];
+  }
+});
+
+// src/lib/simple-git-api.ts
+var simple_git_api_exports = {};
+__export(simple_git_api_exports, {
+  SimpleGitApi: () => SimpleGitApi
+});
+var SimpleGitApi;
+var init_simple_git_api = __esm({
+  "src/lib/simple-git-api.ts"() {
+    init_task_callback();
+    init_change_working_directory();
+    init_checkout();
+    init_commit();
+    init_config();
+    init_grep();
+    init_hash_object();
+    init_init();
+    init_log();
+    init_merge();
+    init_push();
+    init_status();
+    init_task();
+    init_version();
+    init_utils();
+    SimpleGitApi = class {
+      constructor(_executor) {
+        this._executor = _executor;
+      }
+      _runTask(task, then) {
+        const chain = this._executor.chain();
+        const promise = chain.push(task);
+        if (then) {
+          taskCallback(task, promise, then);
+        }
+        return Object.create(this, {
+          then: { value: promise.then.bind(promise) },
+          catch: { value: promise.catch.bind(promise) },
+          _executor: { value: chain }
+        });
+      }
+      add(files) {
+        return this._runTask(straightThroughStringTask(["add", ...asArray(files)]), trailingFunctionArgument(arguments));
+      }
+      cwd(directory) {
+        const next = trailingFunctionArgument(arguments);
+        if (typeof directory === "string") {
+          return this._runTask(changeWorkingDirectoryTask(directory, this._executor), next);
+        }
+        if (typeof (directory == null ? void 0 : directory.path) === "string") {
+          return this._runTask(changeWorkingDirectoryTask(directory.path, directory.root && this._executor || void 0), next);
+        }
+        return this._runTask(configurationErrorTask("Git.cwd: workingDirectory must be supplied as a string"), next);
+      }
+      hashObject(path, write) {
+        return this._runTask(hashObjectTask(path, write === true), trailingFunctionArgument(arguments));
+      }
+      init(bare) {
+        return this._runTask(initTask(bare === true, this._executor.cwd, getTrailingOptions(arguments)), trailingFunctionArgument(arguments));
+      }
+      merge() {
+        return this._runTask(mergeTask(getTrailingOptions(arguments)), trailingFunctionArgument(arguments));
+      }
+      mergeFromTo(remote, branch) {
+        if (!(filterString(remote) && filterString(branch))) {
+          return this._runTask(configurationErrorTask(`Git.mergeFromTo requires that the 'remote' and 'branch' arguments are supplied as strings`));
+        }
+        return this._runTask(mergeTask([remote, branch, ...getTrailingOptions(arguments)]), trailingFunctionArgument(arguments, false));
+      }
+      outputHandler(handler) {
+        this._executor.outputHandler = handler;
+        return this;
+      }
+      push() {
+        const task = pushTask({
+          remote: filterType(arguments[0], filterString),
+          branch: filterType(arguments[1], filterString)
+        }, getTrailingOptions(arguments));
+        return this._runTask(task, trailingFunctionArgument(arguments));
+      }
+      stash() {
+        return this._runTask(straightThroughStringTask(["stash", ...getTrailingOptions(arguments)]), trailingFunctionArgument(arguments));
+      }
+      status() {
+        return this._runTask(statusTask(getTrailingOptions(arguments)), trailingFunctionArgument(arguments));
+      }
+    };
+    Object.assign(SimpleGitApi.prototype, checkout_default(), commit_default(), config_default(), grep_default(), log_default(), version_default());
+  }
+});
+
+// src/lib/runners/scheduler.ts
+var scheduler_exports = {};
+__export(scheduler_exports, {
+  Scheduler: () => Scheduler
+});
+var import_promise_deferred2, createScheduledTask, Scheduler;
+var init_scheduler = __esm({
+  "src/lib/runners/scheduler.ts"() {
+    init_utils();
+    import_promise_deferred2 = __nccwpck_require__(7613);
+    init_git_logger();
+    createScheduledTask = (() => {
+      let id = 0;
+      return () => {
+        id++;
+        const { promise, done } = (0, import_promise_deferred2.createDeferred)();
+        return {
+          promise,
+          done,
+          id
+        };
+      };
+    })();
+    Scheduler = class {
+      constructor(concurrency = 2) {
+        this.concurrency = concurrency;
+        this.logger = createLogger("", "scheduler");
+        this.pending = [];
+        this.running = [];
+        this.logger(`Constructed, concurrency=%s`, concurrency);
+      }
+      schedule() {
+        if (!this.pending.length || this.running.length >= this.concurrency) {
+          this.logger(`Schedule attempt ignored, pending=%s running=%s concurrency=%s`, this.pending.length, this.running.length, this.concurrency);
+          return;
+        }
+        const task = append(this.running, this.pending.shift());
+        this.logger(`Attempting id=%s`, task.id);
+        task.done(() => {
+          this.logger(`Completing id=`, task.id);
+          remove(this.running, task);
+          this.schedule();
+        });
+      }
+      next() {
+        const { promise, id } = append(this.pending, createScheduledTask());
+        this.logger(`Scheduling id=%s`, id);
+        this.schedule();
+        return promise;
+      }
+    };
+  }
+});
+
+// src/lib/tasks/apply-patch.ts
+var apply_patch_exports = {};
+__export(apply_patch_exports, {
+  applyPatchTask: () => applyPatchTask
+});
+function applyPatchTask(patches, customArgs) {
+  return straightThroughStringTask(["apply", ...customArgs, ...patches]);
+}
+var init_apply_patch = __esm({
+  "src/lib/tasks/apply-patch.ts"() {
+    init_task();
+  }
+});
+
+// src/lib/responses/BranchDeleteSummary.ts
+function branchDeletionSuccess(branch, hash) {
+  return {
+    branch,
+    hash,
+    success: true
+  };
+}
+function branchDeletionFailure(branch) {
+  return {
+    branch,
+    hash: null,
+    success: false
+  };
+}
+var BranchDeletionBatch;
+var init_BranchDeleteSummary = __esm({
+  "src/lib/responses/BranchDeleteSummary.ts"() {
+    BranchDeletionBatch = class {
+      constructor() {
+        this.all = [];
+        this.branches = {};
+        this.errors = [];
+      }
+      get success() {
+        return !this.errors.length;
+      }
+    };
+  }
+});
+
+// src/lib/parsers/parse-branch-delete.ts
+function hasBranchDeletionError(data, processExitCode) {
+  return processExitCode === 1 /* ERROR */ && deleteErrorRegex.test(data);
+}
+var deleteSuccessRegex, deleteErrorRegex, parsers8, parseBranchDeletions;
+var init_parse_branch_delete = __esm({
+  "src/lib/parsers/parse-branch-delete.ts"() {
+    init_BranchDeleteSummary();
+    init_utils();
+    deleteSuccessRegex = /(\S+)\s+\(\S+\s([^)]+)\)/;
+    deleteErrorRegex = /^error[^']+'([^']+)'/m;
+    parsers8 = [
+      new LineParser(deleteSuccessRegex, (result, [branch, hash]) => {
+        const deletion = branchDeletionSuccess(branch, hash);
+        result.all.push(deletion);
+        result.branches[branch] = deletion;
+      }),
+      new LineParser(deleteErrorRegex, (result, [branch]) => {
+        const deletion = branchDeletionFailure(branch);
+        result.errors.push(deletion);
+        result.all.push(deletion);
+        result.branches[branch] = deletion;
+      })
+    ];
+    parseBranchDeletions = (stdOut, stdErr) => {
+      return parseStringResponse(new BranchDeletionBatch(), parsers8, [stdOut, stdErr]);
+    };
+  }
+});
+
+// src/lib/responses/BranchSummary.ts
+var BranchSummaryResult;
+var init_BranchSummary = __esm({
+  "src/lib/responses/BranchSummary.ts"() {
+    BranchSummaryResult = class {
+      constructor() {
+        this.all = [];
+        this.branches = {};
+        this.current = "";
+        this.detached = false;
+      }
+      push(status, detached, name, commit, label) {
+        if (status === "*" /* CURRENT */) {
+          this.detached = detached;
+          this.current = name;
+        }
+        this.all.push(name);
+        this.branches[name] = {
+          current: status === "*" /* CURRENT */,
+          linkedWorkTree: status === "+" /* LINKED */,
+          name,
+          commit,
+          label
+        };
+      }
+    };
+  }
+});
+
+// src/lib/parsers/parse-branch.ts
+function branchStatus(input) {
+  return input ? input.charAt(0) : "";
+}
+function parseBranchSummary(stdOut) {
+  return parseStringResponse(new BranchSummaryResult(), parsers9, stdOut);
+}
+var parsers9;
+var init_parse_branch = __esm({
+  "src/lib/parsers/parse-branch.ts"() {
+    init_BranchSummary();
+    init_utils();
+    parsers9 = [
+      new LineParser(/^([*+]\s)?\((?:HEAD )?detached (?:from|at) (\S+)\)\s+([a-z0-9]+)\s(.*)$/, (result, [current, name, commit, label]) => {
+        result.push(branchStatus(current), true, name, commit, label);
+      }),
+      new LineParser(/^([*+]\s)?(\S+)\s+([a-z0-9]+)\s?(.*)$/s, (result, [current, name, commit, label]) => {
+        result.push(branchStatus(current), false, name, commit, label);
+      })
+    ];
+  }
+});
+
+// src/lib/tasks/branch.ts
+var branch_exports = {};
+__export(branch_exports, {
+  branchLocalTask: () => branchLocalTask,
+  branchTask: () => branchTask,
+  containsDeleteBranchCommand: () => containsDeleteBranchCommand,
+  deleteBranchTask: () => deleteBranchTask,
+  deleteBranchesTask: () => deleteBranchesTask
+});
+function containsDeleteBranchCommand(commands) {
+  const deleteCommands = ["-d", "-D", "--delete"];
+  return commands.some((command) => deleteCommands.includes(command));
+}
+function branchTask(customArgs) {
+  const isDelete = containsDeleteBranchCommand(customArgs);
+  const commands = ["branch", ...customArgs];
+  if (commands.length === 1) {
+    commands.push("-a");
+  }
+  if (!commands.includes("-v")) {
+    commands.splice(1, 0, "-v");
+  }
+  return {
+    format: "utf-8",
+    commands,
+    parser(stdOut, stdErr) {
+      if (isDelete) {
+        return parseBranchDeletions(stdOut, stdErr).all[0];
+      }
+      return parseBranchSummary(stdOut);
+    }
+  };
+}
+function branchLocalTask() {
+  const parser3 = parseBranchSummary;
+  return {
+    format: "utf-8",
+    commands: ["branch", "-v"],
+    parser: parser3
+  };
+}
+function deleteBranchesTask(branches, forceDelete = false) {
+  return {
+    format: "utf-8",
+    commands: ["branch", "-v", forceDelete ? "-D" : "-d", ...branches],
+    parser(stdOut, stdErr) {
+      return parseBranchDeletions(stdOut, stdErr);
+    },
+    onError({ exitCode, stdOut }, error, done, fail) {
+      if (!hasBranchDeletionError(String(error), exitCode)) {
+        return fail(error);
+      }
+      done(stdOut);
+    }
+  };
+}
+function deleteBranchTask(branch, forceDelete = false) {
+  const task = {
+    format: "utf-8",
+    commands: ["branch", "-v", forceDelete ? "-D" : "-d", branch],
+    parser(stdOut, stdErr) {
+      return parseBranchDeletions(stdOut, stdErr).branches[branch];
+    },
+    onError({ exitCode, stdErr, stdOut }, error, _, fail) {
+      if (!hasBranchDeletionError(String(error), exitCode)) {
+        return fail(error);
+      }
+      throw new GitResponseError(task.parser(bufferToString(stdOut), bufferToString(stdErr)), String(error));
+    }
+  };
+  return task;
+}
+var init_branch = __esm({
+  "src/lib/tasks/branch.ts"() {
+    init_git_response_error();
+    init_parse_branch_delete();
+    init_parse_branch();
+    init_utils();
+  }
+});
+
+// src/lib/responses/CheckIgnore.ts
+var parseCheckIgnore;
+var init_CheckIgnore = __esm({
+  "src/lib/responses/CheckIgnore.ts"() {
+    parseCheckIgnore = (text) => {
+      return text.split(/\n/g).map((line) => line.trim()).filter((file) => !!file);
+    };
+  }
+});
+
+// src/lib/tasks/check-ignore.ts
+var check_ignore_exports = {};
+__export(check_ignore_exports, {
+  checkIgnoreTask: () => checkIgnoreTask
+});
+function checkIgnoreTask(paths) {
+  return {
+    commands: ["check-ignore", ...paths],
+    format: "utf-8",
+    parser: parseCheckIgnore
+  };
+}
+var init_check_ignore = __esm({
+  "src/lib/tasks/check-ignore.ts"() {
+    init_CheckIgnore();
+  }
+});
+
+// src/lib/tasks/clone.ts
+var clone_exports = {};
+__export(clone_exports, {
+  cloneMirrorTask: () => cloneMirrorTask,
+  cloneTask: () => cloneTask
+});
+function disallowedCommand(command) {
+  return /^--upload-pack(=|$)/.test(command);
+}
+function cloneTask(repo, directory, customArgs) {
+  const commands = ["clone", ...customArgs];
+  filterString(repo) && commands.push(repo);
+  filterString(directory) && commands.push(directory);
+  const banned = commands.find(disallowedCommand);
+  if (banned) {
+    return configurationErrorTask(`git.fetch: potential exploit argument blocked.`);
+  }
+  return straightThroughStringTask(commands);
+}
+function cloneMirrorTask(repo, directory, customArgs) {
+  append(customArgs, "--mirror");
+  return cloneTask(repo, directory, customArgs);
+}
+var init_clone = __esm({
+  "src/lib/tasks/clone.ts"() {
+    init_task();
+    init_utils();
+  }
+});
+
+// src/lib/parsers/parse-fetch.ts
+function parseFetchResult(stdOut, stdErr) {
+  const result = {
+    raw: stdOut,
+    remote: null,
+    branches: [],
+    tags: [],
+    updated: [],
+    deleted: []
+  };
+  return parseStringResponse(result, parsers10, [stdOut, stdErr]);
+}
+var parsers10;
+var init_parse_fetch = __esm({
+  "src/lib/parsers/parse-fetch.ts"() {
+    init_utils();
+    parsers10 = [
+      new LineParser(/From (.+)$/, (result, [remote]) => {
+        result.remote = remote;
+      }),
+      new LineParser(/\* \[new branch]\s+(\S+)\s*-> (.+)$/, (result, [name, tracking]) => {
+        result.branches.push({
+          name,
+          tracking
+        });
+      }),
+      new LineParser(/\* \[new tag]\s+(\S+)\s*-> (.+)$/, (result, [name, tracking]) => {
+        result.tags.push({
+          name,
+          tracking
+        });
+      }),
+      new LineParser(/- \[deleted]\s+\S+\s*-> (.+)$/, (result, [tracking]) => {
+        result.deleted.push({
+          tracking
+        });
+      }),
+      new LineParser(/\s*([^.]+)\.\.(\S+)\s+(\S+)\s*-> (.+)$/, (result, [from, to, name, tracking]) => {
+        result.updated.push({
+          name,
+          tracking,
+          to,
+          from
+        });
+      })
+    ];
+  }
+});
+
+// src/lib/tasks/fetch.ts
+var fetch_exports = {};
+__export(fetch_exports, {
+  fetchTask: () => fetchTask
+});
+function disallowedCommand2(command) {
+  return /^--upload-pack(=|$)/.test(command);
+}
+function fetchTask(remote, branch, customArgs) {
+  const commands = ["fetch", ...customArgs];
+  if (remote && branch) {
+    commands.push(remote, branch);
+  }
+  const banned = commands.find(disallowedCommand2);
+  if (banned) {
+    return configurationErrorTask(`git.fetch: potential exploit argument blocked.`);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser: parseFetchResult
+  };
+}
+var init_fetch = __esm({
+  "src/lib/tasks/fetch.ts"() {
+    init_parse_fetch();
+    init_task();
+  }
+});
+
+// src/lib/parsers/parse-move.ts
+function parseMoveResult(stdOut) {
+  return parseStringResponse({ moves: [] }, parsers11, stdOut);
+}
+var parsers11;
+var init_parse_move = __esm({
+  "src/lib/parsers/parse-move.ts"() {
+    init_utils();
+    parsers11 = [
+      new LineParser(/^Renaming (.+) to (.+)$/, (result, [from, to]) => {
+        result.moves.push({ from, to });
+      })
+    ];
+  }
+});
+
+// src/lib/tasks/move.ts
+var move_exports = {};
+__export(move_exports, {
+  moveTask: () => moveTask
+});
+function moveTask(from, to) {
+  return {
+    commands: ["mv", "-v", ...asArray(from), to],
+    format: "utf-8",
+    parser: parseMoveResult
+  };
+}
+var init_move = __esm({
+  "src/lib/tasks/move.ts"() {
+    init_parse_move();
+    init_utils();
+  }
+});
+
+// src/lib/tasks/pull.ts
+var pull_exports = {};
+__export(pull_exports, {
+  pullTask: () => pullTask
+});
+function pullTask(remote, branch, customArgs) {
+  const commands = ["pull", ...customArgs];
+  if (remote && branch) {
+    commands.splice(1, 0, remote, branch);
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser(stdOut, stdErr) {
+      return parsePullResult(stdOut, stdErr);
+    },
+    onError(result, _error, _done, fail) {
+      const pullError = parsePullErrorResult(bufferToString(result.stdOut), bufferToString(result.stdErr));
+      if (pullError) {
+        return fail(new GitResponseError(pullError));
+      }
+      fail(_error);
+    }
+  };
+}
+var init_pull = __esm({
+  "src/lib/tasks/pull.ts"() {
+    init_git_response_error();
+    init_parse_pull();
+    init_utils();
+  }
+});
+
+// src/lib/responses/GetRemoteSummary.ts
+function parseGetRemotes(text) {
+  const remotes = {};
+  forEach(text, ([name]) => remotes[name] = { name });
+  return Object.values(remotes);
+}
+function parseGetRemotesVerbose(text) {
+  const remotes = {};
+  forEach(text, ([name, url, purpose]) => {
+    if (!remotes.hasOwnProperty(name)) {
+      remotes[name] = {
+        name,
+        refs: { fetch: "", push: "" }
+      };
+    }
+    if (purpose && url) {
+      remotes[name].refs[purpose.replace(/[^a-z]/g, "")] = url;
+    }
+  });
+  return Object.values(remotes);
+}
+function forEach(text, handler) {
+  forEachLineWithContent(text, (line) => handler(line.split(/\s+/)));
+}
+var init_GetRemoteSummary = __esm({
+  "src/lib/responses/GetRemoteSummary.ts"() {
+    init_utils();
+  }
+});
+
+// src/lib/tasks/remote.ts
+var remote_exports = {};
+__export(remote_exports, {
+  addRemoteTask: () => addRemoteTask,
+  getRemotesTask: () => getRemotesTask,
+  listRemotesTask: () => listRemotesTask,
+  remoteTask: () => remoteTask,
+  removeRemoteTask: () => removeRemoteTask
+});
+function addRemoteTask(remoteName, remoteRepo, customArgs = []) {
+  return straightThroughStringTask(["remote", "add", ...customArgs, remoteName, remoteRepo]);
+}
+function getRemotesTask(verbose) {
+  const commands = ["remote"];
+  if (verbose) {
+    commands.push("-v");
+  }
+  return {
+    commands,
+    format: "utf-8",
+    parser: verbose ? parseGetRemotesVerbose : parseGetRemotes
+  };
+}
+function listRemotesTask(customArgs = []) {
+  const commands = [...customArgs];
+  if (commands[0] !== "ls-remote") {
+    commands.unshift("ls-remote");
+  }
+  return straightThroughStringTask(commands);
+}
+function remoteTask(customArgs = []) {
+  const commands = [...customArgs];
+  if (commands[0] !== "remote") {
+    commands.unshift("remote");
+  }
+  return straightThroughStringTask(commands);
+}
+function removeRemoteTask(remoteName) {
+  return straightThroughStringTask(["remote", "remove", remoteName]);
+}
+var init_remote = __esm({
+  "src/lib/tasks/remote.ts"() {
+    init_GetRemoteSummary();
+    init_task();
+  }
+});
+
+// src/lib/tasks/stash-list.ts
+var stash_list_exports = {};
+__export(stash_list_exports, {
+  stashListTask: () => stashListTask
+});
+function stashListTask(opt = {}, customArgs) {
+  const options = parseLogOptions(opt);
+  const commands = ["stash", "list", ...options.commands, ...customArgs];
+  const parser3 = createListLogSummaryParser(options.splitter, options.fields, logFormatFromCommand(commands));
+  return validateLogFormatConfig(commands) || {
+    commands,
+    format: "utf-8",
+    parser: parser3
+  };
+}
+var init_stash_list = __esm({
+  "src/lib/tasks/stash-list.ts"() {
+    init_log_format();
+    init_parse_list_log_summary();
+    init_diff();
+    init_log();
+  }
+});
+
+// src/lib/tasks/sub-module.ts
+var sub_module_exports = {};
+__export(sub_module_exports, {
+  addSubModuleTask: () => addSubModuleTask,
+  initSubModuleTask: () => initSubModuleTask,
+  subModuleTask: () => subModuleTask,
+  updateSubModuleTask: () => updateSubModuleTask
+});
+function addSubModuleTask(repo, path) {
+  return subModuleTask(["add", repo, path]);
+}
+function initSubModuleTask(customArgs) {
+  return subModuleTask(["init", ...customArgs]);
+}
+function subModuleTask(customArgs) {
+  const commands = [...customArgs];
+  if (commands[0] !== "submodule") {
+    commands.unshift("submodule");
+  }
+  return straightThroughStringTask(commands);
+}
+function updateSubModuleTask(customArgs) {
+  return subModuleTask(["update", ...customArgs]);
+}
+var init_sub_module = __esm({
+  "src/lib/tasks/sub-module.ts"() {
+    init_task();
+  }
+});
+
+// src/lib/responses/TagList.ts
+function singleSorted(a, b) {
+  const aIsNum = isNaN(a);
+  const bIsNum = isNaN(b);
+  if (aIsNum !== bIsNum) {
+    return aIsNum ? 1 : -1;
+  }
+  return aIsNum ? sorted(a, b) : 0;
+}
+function sorted(a, b) {
+  return a === b ? 0 : a > b ? 1 : -1;
+}
+function trimmed(input) {
+  return input.trim();
+}
+function toNumber(input) {
+  if (typeof input === "string") {
+    return parseInt(input.replace(/^\D+/g, ""), 10) || 0;
+  }
+  return 0;
+}
+var TagList, parseTagList;
+var init_TagList = __esm({
+  "src/lib/responses/TagList.ts"() {
+    TagList = class {
+      constructor(all, latest) {
+        this.all = all;
+        this.latest = latest;
+      }
+    };
+    parseTagList = function(data, customSort = false) {
+      const tags = data.split("\n").map(trimmed).filter(Boolean);
+      if (!customSort) {
+        tags.sort(function(tagA, tagB) {
+          const partsA = tagA.split(".");
+          const partsB = tagB.split(".");
+          if (partsA.length === 1 || partsB.length === 1) {
+            return singleSorted(toNumber(partsA[0]), toNumber(partsB[0]));
+          }
+          for (let i = 0, l = Math.max(partsA.length, partsB.length); i < l; i++) {
+            const diff = sorted(toNumber(partsA[i]), toNumber(partsB[i]));
+            if (diff) {
+              return diff;
+            }
+          }
+          return 0;
+        });
+      }
+      const latest = customSort ? tags[0] : [...tags].reverse().find((tag) => tag.indexOf(".") >= 0);
+      return new TagList(tags, latest);
+    };
+  }
+});
+
+// src/lib/tasks/tag.ts
+var tag_exports = {};
+__export(tag_exports, {
+  addAnnotatedTagTask: () => addAnnotatedTagTask,
+  addTagTask: () => addTagTask,
+  tagListTask: () => tagListTask
+});
+function tagListTask(customArgs = []) {
+  const hasCustomSort = customArgs.some((option) => /^--sort=/.test(option));
+  return {
+    format: "utf-8",
+    commands: ["tag", "-l", ...customArgs],
+    parser(text) {
+      return parseTagList(text, hasCustomSort);
+    }
+  };
+}
+function addTagTask(name) {
+  return {
+    format: "utf-8",
+    commands: ["tag", name],
+    parser() {
+      return { name };
+    }
+  };
+}
+function addAnnotatedTagTask(name, tagMessage) {
+  return {
+    format: "utf-8",
+    commands: ["tag", "-a", "-m", tagMessage, name],
+    parser() {
+      return { name };
+    }
+  };
+}
+var init_tag = __esm({
+  "src/lib/tasks/tag.ts"() {
+    init_TagList();
+  }
+});
+
+// src/git.js
+var require_git = __commonJS({
+  "src/git.js"(exports2, module2) {
+    var { GitExecutor: GitExecutor2 } = (init_git_executor(), __toCommonJS(git_executor_exports));
+    var { SimpleGitApi: SimpleGitApi2 } = (init_simple_git_api(), __toCommonJS(simple_git_api_exports));
+    var { Scheduler: Scheduler2 } = (init_scheduler(), __toCommonJS(scheduler_exports));
+    var { configurationErrorTask: configurationErrorTask2 } = (init_task(), __toCommonJS(task_exports));
+    var {
+      asArray: asArray2,
+      filterArray: filterArray2,
+      filterPrimitives: filterPrimitives2,
+      filterString: filterString2,
+      filterStringOrStringArray: filterStringOrStringArray2,
+      filterType: filterType2,
+      getTrailingOptions: getTrailingOptions2,
+      trailingFunctionArgument: trailingFunctionArgument2,
+      trailingOptionsArgument: trailingOptionsArgument2
+    } = (init_utils(), __toCommonJS(utils_exports));
+    var { applyPatchTask: applyPatchTask2 } = (init_apply_patch(), __toCommonJS(apply_patch_exports));
+    var {
+      branchTask: branchTask2,
+      branchLocalTask: branchLocalTask2,
+      deleteBranchesTask: deleteBranchesTask2,
+      deleteBranchTask: deleteBranchTask2
+    } = (init_branch(), __toCommonJS(branch_exports));
+    var { checkIgnoreTask: checkIgnoreTask2 } = (init_check_ignore(), __toCommonJS(check_ignore_exports));
+    var { checkIsRepoTask: checkIsRepoTask2 } = (init_check_is_repo(), __toCommonJS(check_is_repo_exports));
+    var { cloneTask: cloneTask2, cloneMirrorTask: cloneMirrorTask2 } = (init_clone(), __toCommonJS(clone_exports));
+    var { cleanWithOptionsTask: cleanWithOptionsTask2, isCleanOptionsArray: isCleanOptionsArray2 } = (init_clean(), __toCommonJS(clean_exports));
+    var { diffSummaryTask: diffSummaryTask2 } = (init_diff(), __toCommonJS(diff_exports));
+    var { fetchTask: fetchTask2 } = (init_fetch(), __toCommonJS(fetch_exports));
+    var { moveTask: moveTask2 } = (init_move(), __toCommonJS(move_exports));
+    var { pullTask: pullTask2 } = (init_pull(), __toCommonJS(pull_exports));
+    var { pushTagsTask: pushTagsTask2 } = (init_push(), __toCommonJS(push_exports));
+    var {
+      addRemoteTask: addRemoteTask2,
+      getRemotesTask: getRemotesTask2,
+      listRemotesTask: listRemotesTask2,
+      remoteTask: remoteTask2,
+      removeRemoteTask: removeRemoteTask2
+    } = (init_remote(), __toCommonJS(remote_exports));
+    var { getResetMode: getResetMode2, resetTask: resetTask2 } = (init_reset(), __toCommonJS(reset_exports));
+    var { stashListTask: stashListTask2 } = (init_stash_list(), __toCommonJS(stash_list_exports));
+    var {
+      addSubModuleTask: addSubModuleTask2,
+      initSubModuleTask: initSubModuleTask2,
+      subModuleTask: subModuleTask2,
+      updateSubModuleTask: updateSubModuleTask2
+    } = (init_sub_module(), __toCommonJS(sub_module_exports));
+    var { addAnnotatedTagTask: addAnnotatedTagTask2, addTagTask: addTagTask2, tagListTask: tagListTask2 } = (init_tag(), __toCommonJS(tag_exports));
+    var { straightThroughBufferTask: straightThroughBufferTask2, straightThroughStringTask: straightThroughStringTask2 } = (init_task(), __toCommonJS(task_exports));
+    function Git2(options, plugins) {
+      this._executor = new GitExecutor2(options.binary, options.baseDir, new Scheduler2(options.maxConcurrentProcesses), plugins);
+      this._trimmed = options.trimmed;
+    }
+    (Git2.prototype = Object.create(SimpleGitApi2.prototype)).constructor = Git2;
+    Git2.prototype.customBinary = function(command) {
+      this._executor.binary = command;
+      return this;
+    };
+    Git2.prototype.env = function(name, value) {
+      if (arguments.length === 1 && typeof name === "object") {
+        this._executor.env = name;
+      } else {
+        (this._executor.env = this._executor.env || {})[name] = value;
+      }
+      return this;
+    };
+    Git2.prototype.stashList = function(options) {
+      return this._runTask(stashListTask2(trailingOptionsArgument2(arguments) || {}, filterArray2(options) && options || []), trailingFunctionArgument2(arguments));
+    };
+    function createCloneTask(api, task, repoPath, localPath) {
+      if (typeof repoPath !== "string") {
+        return configurationErrorTask2(`git.${api}() requires a string 'repoPath'`);
+      }
+      return task(repoPath, filterType2(localPath, filterString2), getTrailingOptions2(arguments));
+    }
+    Git2.prototype.clone = function() {
+      return this._runTask(createCloneTask("clone", cloneTask2, ...arguments), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.mirror = function() {
+      return this._runTask(createCloneTask("mirror", cloneMirrorTask2, ...arguments), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.mv = function(from, to) {
+      return this._runTask(moveTask2(from, to), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.checkoutLatestTag = function(then) {
+      var git = this;
+      return this.pull(function() {
+        git.tags(function(err, tags) {
+          git.checkout(tags.latest, then);
+        });
+      });
+    };
+    Git2.prototype.pull = function(remote, branch, options, then) {
+      return this._runTask(pullTask2(filterType2(remote, filterString2), filterType2(branch, filterString2), getTrailingOptions2(arguments)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.fetch = function(remote, branch) {
+      return this._runTask(fetchTask2(filterType2(remote, filterString2), filterType2(branch, filterString2), getTrailingOptions2(arguments)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.silent = function(silence) {
+      console.warn("simple-git deprecation notice: git.silent: logging should be configured using the `debug` library / `DEBUG` environment variable, this will be an error in version 3");
+      return this;
+    };
+    Git2.prototype.tags = function(options, then) {
+      return this._runTask(tagListTask2(getTrailingOptions2(arguments)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.rebase = function() {
+      return this._runTask(straightThroughStringTask2(["rebase", ...getTrailingOptions2(arguments)]), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.reset = function(mode) {
+      return this._runTask(resetTask2(getResetMode2(mode), getTrailingOptions2(arguments)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.revert = function(commit) {
+      const next = trailingFunctionArgument2(arguments);
+      if (typeof commit !== "string") {
+        return this._runTask(configurationErrorTask2("Commit must be a string"), next);
+      }
+      return this._runTask(straightThroughStringTask2(["revert", ...getTrailingOptions2(arguments, 0, true), commit]), next);
+    };
+    Git2.prototype.addTag = function(name) {
+      const task = typeof name === "string" ? addTagTask2(name) : configurationErrorTask2("Git.addTag requires a tag name");
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.addAnnotatedTag = function(tagName, tagMessage) {
+      return this._runTask(addAnnotatedTagTask2(tagName, tagMessage), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.deleteLocalBranch = function(branchName, forceDelete, then) {
+      return this._runTask(deleteBranchTask2(branchName, typeof forceDelete === "boolean" ? forceDelete : false), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.deleteLocalBranches = function(branchNames, forceDelete, then) {
+      return this._runTask(deleteBranchesTask2(branchNames, typeof forceDelete === "boolean" ? forceDelete : false), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.branch = function(options, then) {
+      return this._runTask(branchTask2(getTrailingOptions2(arguments)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.branchLocal = function(then) {
+      return this._runTask(branchLocalTask2(), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.raw = function(commands) {
+      const createRestCommands = !Array.isArray(commands);
+      const command = [].slice.call(createRestCommands ? arguments : commands, 0);
+      for (let i = 0; i < command.length && createRestCommands; i++) {
+        if (!filterPrimitives2(command[i])) {
+          command.splice(i, command.length - i);
+          break;
+        }
+      }
+      command.push(...getTrailingOptions2(arguments, 0, true));
+      var next = trailingFunctionArgument2(arguments);
+      if (!command.length) {
+        return this._runTask(configurationErrorTask2("Raw: must supply one or more command to execute"), next);
+      }
+      return this._runTask(straightThroughStringTask2(command, this._trimmed), next);
+    };
+    Git2.prototype.submoduleAdd = function(repo, path, then) {
+      return this._runTask(addSubModuleTask2(repo, path), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.submoduleUpdate = function(args, then) {
+      return this._runTask(updateSubModuleTask2(getTrailingOptions2(arguments, true)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.submoduleInit = function(args, then) {
+      return this._runTask(initSubModuleTask2(getTrailingOptions2(arguments, true)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.subModule = function(options, then) {
+      return this._runTask(subModuleTask2(getTrailingOptions2(arguments)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.listRemote = function() {
+      return this._runTask(listRemotesTask2(getTrailingOptions2(arguments)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.addRemote = function(remoteName, remoteRepo, then) {
+      return this._runTask(addRemoteTask2(remoteName, remoteRepo, getTrailingOptions2(arguments)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.removeRemote = function(remoteName, then) {
+      return this._runTask(removeRemoteTask2(remoteName), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.getRemotes = function(verbose, then) {
+      return this._runTask(getRemotesTask2(verbose === true), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.remote = function(options, then) {
+      return this._runTask(remoteTask2(getTrailingOptions2(arguments)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.tag = function(options, then) {
+      const command = getTrailingOptions2(arguments);
+      if (command[0] !== "tag") {
+        command.unshift("tag");
+      }
+      return this._runTask(straightThroughStringTask2(command), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.updateServerInfo = function(then) {
+      return this._runTask(straightThroughStringTask2(["update-server-info"]), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.pushTags = function(remote, then) {
+      const task = pushTagsTask2({ remote: filterType2(remote, filterString2) }, getTrailingOptions2(arguments));
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.rm = function(files) {
+      return this._runTask(straightThroughStringTask2(["rm", "-f", ...asArray2(files)]), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.rmKeepLocal = function(files) {
+      return this._runTask(straightThroughStringTask2(["rm", "--cached", ...asArray2(files)]), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.catFile = function(options, then) {
+      return this._catFile("utf-8", arguments);
+    };
+    Git2.prototype.binaryCatFile = function() {
+      return this._catFile("buffer", arguments);
+    };
+    Git2.prototype._catFile = function(format, args) {
+      var handler = trailingFunctionArgument2(args);
+      var command = ["cat-file"];
+      var options = args[0];
+      if (typeof options === "string") {
+        return this._runTask(configurationErrorTask2("Git.catFile: options must be supplied as an array of strings"), handler);
+      }
+      if (Array.isArray(options)) {
+        command.push.apply(command, options);
+      }
+      const task = format === "buffer" ? straightThroughBufferTask2(command) : straightThroughStringTask2(command);
+      return this._runTask(task, handler);
+    };
+    Git2.prototype.diff = function(options, then) {
+      const task = filterString2(options) ? configurationErrorTask2("git.diff: supplying options as a single string is no longer supported, switch to an array of strings") : straightThroughStringTask2(["diff", ...getTrailingOptions2(arguments)]);
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.diffSummary = function() {
+      return this._runTask(diffSummaryTask2(getTrailingOptions2(arguments, 1)), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.applyPatch = function(patches) {
+      const task = !filterStringOrStringArray2(patches) ? configurationErrorTask2(`git.applyPatch requires one or more string patches as the first argument`) : applyPatchTask2(asArray2(patches), getTrailingOptions2([].slice.call(arguments, 1)));
+      return this._runTask(task, trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.revparse = function() {
+      const commands = ["rev-parse", ...getTrailingOptions2(arguments, true)];
+      return this._runTask(straightThroughStringTask2(commands, true), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.show = function(options, then) {
+      return this._runTask(straightThroughStringTask2(["show", ...getTrailingOptions2(arguments, 1)]), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.clean = function(mode, options, then) {
+      const usingCleanOptionsArray = isCleanOptionsArray2(mode);
+      const cleanMode = usingCleanOptionsArray && mode.join("") || filterType2(mode, filterString2) || "";
+      const customArgs = getTrailingOptions2([].slice.call(arguments, usingCleanOptionsArray ? 1 : 0));
+      return this._runTask(cleanWithOptionsTask2(cleanMode, customArgs), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.exec = function(then) {
+      const task = {
+        commands: [],
+        format: "utf-8",
+        parser() {
+          if (typeof then === "function") {
+            then();
+          }
+        }
+      };
+      return this._runTask(task);
+    };
+    Git2.prototype.clearQueue = function() {
+      return this;
+    };
+    Git2.prototype.checkIgnore = function(pathnames, then) {
+      return this._runTask(checkIgnoreTask2(asArray2(filterType2(pathnames, filterStringOrStringArray2, []))), trailingFunctionArgument2(arguments));
+    };
+    Git2.prototype.checkIsRepo = function(checkType, then) {
+      return this._runTask(checkIsRepoTask2(filterType2(checkType, filterString2)), trailingFunctionArgument2(arguments));
+    };
+    module2.exports = Git2;
+  }
+});
+
+// src/lib/git-factory.ts
+var git_factory_exports = {};
+__export(git_factory_exports, {
+  esModuleFactory: () => esModuleFactory,
+  gitExportFactory: () => gitExportFactory,
+  gitInstanceFactory: () => gitInstanceFactory
+});
+function esModuleFactory(defaultExport) {
+  return Object.defineProperties(defaultExport, {
+    __esModule: { value: true },
+    default: { value: defaultExport }
+  });
+}
+function gitExportFactory(factory) {
+  return Object.assign(factory.bind(null), api_exports);
+}
+function gitInstanceFactory(baseDir, options) {
+  const plugins = new PluginStore();
+  const config = createInstanceConfig(baseDir && (typeof baseDir === "string" ? { baseDir } : baseDir) || {}, options);
+  if (!folderExists(config.baseDir)) {
+    throw new GitConstructError(config, `Cannot use simple-git on a directory that does not exist`);
+  }
+  if (Array.isArray(config.config)) {
+    plugins.add(commandConfigPrefixingPlugin(config.config));
+  }
+  plugins.add(blockUnsafeOperationsPlugin(config.unsafe));
+  plugins.add(completionDetectionPlugin(config.completion));
+  config.abort && plugins.add(abortPlugin(config.abort));
+  config.progress && plugins.add(progressMonitorPlugin(config.progress));
+  config.timeout && plugins.add(timeoutPlugin(config.timeout));
+  config.spawnOptions && plugins.add(spawnOptionsPlugin(config.spawnOptions));
+  plugins.add(errorDetectionPlugin(errorDetectionHandler(true)));
+  config.errors && plugins.add(errorDetectionPlugin(config.errors));
+  return new Git(config, plugins);
+}
+var Git;
+var init_git_factory = __esm({
+  "src/lib/git-factory.ts"() {
+    init_api();
+    init_plugins();
+    init_utils();
+    Git = require_git();
+  }
+});
+
+// src/lib/runners/promise-wrapped.ts
+var promise_wrapped_exports = {};
+__export(promise_wrapped_exports, {
+  gitP: () => gitP
+});
+function gitP(...args) {
+  let git;
+  let chain = Promise.resolve();
+  try {
+    git = gitInstanceFactory(...args);
+  } catch (e) {
+    chain = Promise.reject(e);
+  }
+  function builderReturn() {
+    return promiseApi;
+  }
+  function chainReturn() {
+    return chain;
+  }
+  const promiseApi = [...functionNamesBuilderApi, ...functionNamesPromiseApi].reduce((api, name) => {
+    const isAsync = functionNamesPromiseApi.includes(name);
+    const valid = isAsync ? asyncWrapper(name, git) : syncWrapper(name, git, api);
+    const alternative = isAsync ? chainReturn : builderReturn;
+    Object.defineProperty(api, name, {
+      enumerable: false,
+      configurable: false,
+      value: git ? valid : alternative
+    });
+    return api;
+  }, {});
+  return promiseApi;
+  function asyncWrapper(fn, git2) {
+    return function(...args2) {
+      if (typeof args2[args2.length] === "function") {
+        throw new TypeError("Promise interface requires that handlers are not supplied inline, trailing function not allowed in call to " + fn);
+      }
+      return chain.then(function() {
+        return new Promise(function(resolve, reject) {
+          const callback = (err, result) => {
+            if (err) {
+              return reject(toError(err));
+            }
+            resolve(result);
+          };
+          args2.push(callback);
+          git2[fn].apply(git2, args2);
+        });
+      });
+    };
+  }
+  function syncWrapper(fn, git2, api) {
+    return (...args2) => {
+      git2[fn](...args2);
+      return api;
+    };
+  }
+}
+function toError(error) {
+  if (error instanceof Error) {
+    return error;
+  }
+  if (typeof error === "string") {
+    return new Error(error);
+  }
+  return new GitResponseError(error);
+}
+var functionNamesBuilderApi, functionNamesPromiseApi;
+var init_promise_wrapped = __esm({
+  "src/lib/runners/promise-wrapped.ts"() {
+    init_git_response_error();
+    init_git_factory();
+    functionNamesBuilderApi = ["customBinary", "env", "outputHandler", "silent"];
+    functionNamesPromiseApi = [
+      "add",
+      "addAnnotatedTag",
+      "addConfig",
+      "addRemote",
+      "addTag",
+      "applyPatch",
+      "binaryCatFile",
+      "branch",
+      "branchLocal",
+      "catFile",
+      "checkIgnore",
+      "checkIsRepo",
+      "checkout",
+      "checkoutBranch",
+      "checkoutLatestTag",
+      "checkoutLocalBranch",
+      "clean",
+      "clone",
+      "commit",
+      "cwd",
+      "deleteLocalBranch",
+      "deleteLocalBranches",
+      "diff",
+      "diffSummary",
+      "exec",
+      "fetch",
+      "getRemotes",
+      "init",
+      "listConfig",
+      "listRemote",
+      "log",
+      "merge",
+      "mergeFromTo",
+      "mirror",
+      "mv",
+      "pull",
+      "push",
+      "pushTags",
+      "raw",
+      "rebase",
+      "remote",
+      "removeRemote",
+      "reset",
+      "revert",
+      "revparse",
+      "rm",
+      "rmKeepLocal",
+      "show",
+      "stash",
+      "stashList",
+      "status",
+      "subModule",
+      "submoduleAdd",
+      "submoduleInit",
+      "submoduleUpdate",
+      "tag",
+      "tags",
+      "updateServerInfo"
+    ];
+  }
+});
+
+// src/index.js
+var { gitP: gitP2 } = (init_promise_wrapped(), __toCommonJS(promise_wrapped_exports));
+var { esModuleFactory: esModuleFactory2, gitInstanceFactory: gitInstanceFactory2, gitExportFactory: gitExportFactory2 } = (init_git_factory(), __toCommonJS(git_factory_exports));
+var simpleGit = esModuleFactory2(gitExportFactory2(gitInstanceFactory2));
+module.exports = Object.assign(simpleGit, { gitP: gitP2, simpleGit });
+//# sourceMappingURL=index.js.map
+
+
+/***/ }),
+
 /***/ 8174:
 /***/ ((module) => {
 
@@ -29242,38 +33574,93 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.compileAction = void 0;
+exports.compileAction = exports.compile = exports.autoVersion = void 0;
 const core_1 = __nccwpck_require__(2186);
 const docker_1 = __nccwpck_require__(6512);
 const particle_api_1 = __nccwpck_require__(6032);
 const util_1 = __nccwpck_require__(2629);
+const versioning_1 = __nccwpck_require__(5622);
+const git_1 = __nccwpck_require__(6350);
+function resolveInputs() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const auth = (0, core_1.getInput)('particle-access-token');
+        const platform = (0, core_1.getInput)('particle-platform-name');
+        const version = (0, core_1.getInput)('device-os-version');
+        const sources = (0, core_1.getInput)('sources-folder');
+        const autoVersionEnabled = (0, core_1.getInput)('auto-version') === 'true';
+        const versionMacroName = (0, core_1.getInput)('auto-version-macro-name');
+        (0, util_1.validatePlatformName)(platform);
+        const targetVersion = yield (0, util_1.resolveVersion)(platform, version);
+        yield (0, util_1.validatePlatformDeviceOsTarget)(platform, targetVersion);
+        return { auth, platform, sources, autoVersionEnabled, versionMacroName, targetVersion };
+    });
+}
+function autoVersion({ sources, gitRepo, autoVersionEnabled, versionMacroName }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let autoVersionFile;
+        let autoVersionNext;
+        let incremented = false;
+        if (autoVersionEnabled) {
+            const productFirmware = yield (0, versioning_1.isProductFirmware)({
+                sources, productVersionMacroName: versionMacroName
+            });
+            if (!productFirmware) {
+                throw new Error('Auto-versioning is enabled, but the firmware does not appear to be a product firmware. The version macro could not be found. Please disable auto-versioning or specify the correct macro name.');
+            }
+            (0, core_1.info)('Auto-versioning is enabled, checking if firmware version should be incremented');
+            autoVersionFile = yield (0, git_1.findProductVersionMacroFile)(sources, versionMacroName);
+            autoVersionNext = yield (0, git_1.currentFirmwareVersion)(gitRepo, autoVersionFile, versionMacroName);
+            const shouldVersion = yield (0, versioning_1.shouldIncrementVersion)({
+                gitRepo, sources, productVersionMacroName: versionMacroName
+            });
+            if (shouldVersion) {
+                const out = yield (0, versioning_1.incrementVersion)({
+                    gitRepo,
+                    sources,
+                    productVersionMacroName: versionMacroName
+                });
+                autoVersionNext = out.version;
+                autoVersionFile = out.file;
+                incremented = true;
+            }
+        }
+        return { autoVersionFile, autoVersionNext, incremented };
+    });
+}
+exports.autoVersion = autoVersion;
+function compile({ auth, platform, sources, targetVersion }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let outputPath;
+        if (!auth) {
+            (0, core_1.info)('No access token provided, running local compilation');
+            yield (0, docker_1.dockerCheck)();
+            outputPath = yield (0, docker_1.dockerBuildpackCompile)({ sources, platform, targetVersion, workingDir: process.cwd() });
+        }
+        else {
+            (0, core_1.info)('Access token provided, running cloud compilation');
+            const binaryId = yield (0, particle_api_1.particleCloudCompile)({ sources, platform, targetVersion, auth });
+            if (!binaryId) {
+                throw new Error('Failed to compile code in cloud');
+            }
+            outputPath = yield (0, particle_api_1.particleDownloadBinary)({ binaryId, auth });
+        }
+        return { outputPath };
+    });
+}
+exports.compile = compile;
 function compileAction() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const auth = (0, core_1.getInput)('particle-access-token');
-            const platform = (0, core_1.getInput)('particle-platform-name');
-            const version = (0, core_1.getInput)('device-os-version');
-            const sources = (0, core_1.getInput)('sources-folder');
-            (0, util_1.validatePlatformName)(platform);
-            const targetVersion = yield (0, util_1.resolveVersion)(platform, version);
-            yield (0, util_1.validatePlatformDeviceOsTarget)(platform, targetVersion);
-            let outputPath;
-            if (!auth) {
-                (0, core_1.info)('No access token provided, running local compilation');
-                yield (0, docker_1.dockerCheck)();
-                outputPath = yield (0, docker_1.dockerBuildpackCompile)({ sources, platform, targetVersion, workingDir: process.cwd() });
-            }
-            else {
-                (0, core_1.info)('Access token provided, running cloud compilation');
-                const binaryId = yield (0, particle_api_1.particleCloudCompile)({ sources, platform, targetVersion, auth });
-                if (!binaryId) {
-                    throw new Error('Failed to compile code in cloud');
-                }
-                outputPath = yield (0, particle_api_1.particleDownloadBinary)({ binaryId, auth });
-            }
+            const { auth, platform, sources, autoVersionEnabled, versionMacroName, targetVersion } = yield resolveInputs();
+            const gitRepo = yield (0, git_1.findNearestGitRoot)(sources);
+            const { autoVersionNext } = yield autoVersion({
+                sources, gitRepo, autoVersionEnabled, versionMacroName
+            });
+            const { outputPath } = yield compile({ auth, platform, sources, targetVersion });
             if (outputPath) {
                 (0, core_1.setOutput)('artifact-path', outputPath);
                 (0, core_1.setOutput)('device-os-version', targetVersion);
+                (0, core_1.setOutput)('firmware-version', autoVersionNext);
             }
             else {
                 (0, core_1.setFailed)(`Failed to compile code in '${sources}'`);
@@ -29370,6 +33757,144 @@ function dockerBuildpackCompile({ workingDir, sources, platform, targetVersion }
     });
 }
 exports.dockerBuildpackCompile = dockerBuildpackCompile;
+
+
+/***/ }),
+
+/***/ 6350:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.mostRecentRevisionInFolder = exports.findNearestGitRoot = exports.findProductVersionMacroFile = exports.revisionOfLastVersionBump = exports.currentFirmwareVersion = void 0;
+const promises_1 = __nccwpck_require__(3292);
+const path_1 = __nccwpck_require__(1017);
+const simple_git_1 = __importDefault(__nccwpck_require__(9103));
+function currentFirmwareVersion(gitRepo, versionFilePath, productVersionMacroName) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const git = (0, simple_git_1.default)(gitRepo);
+        // Get the commit history with patch details for the version file
+        const logs = yield git.log({
+            '-p': null,
+            '--': null,
+            file: versionFilePath
+        });
+        let highestVersion = 0;
+        // if versionFilePath starts with gitRepo, remove it
+        if (versionFilePath.startsWith(gitRepo)) {
+            versionFilePath = versionFilePath.substring(gitRepo.length + 1);
+        }
+        for (const log of logs.all) {
+            const currentCommit = log.hash;
+            const commitBody = yield git.show([`${currentCommit}:${versionFilePath}`]);
+            // Use regex to extract the PRODUCT_VERSION from the patch
+            const versionRegex = new RegExp(`^.*${productVersionMacroName}.*\\((\\d+)\\)`, 'gm');
+            const match = versionRegex.exec(commitBody);
+            if (match) {
+                const currentVersion = parseInt(match[1], 10);
+                // Check if the current version is higher than the previous version and higher than the highest version found
+                if (currentVersion > highestVersion) {
+                    highestVersion = currentVersion;
+                }
+            }
+        }
+        return highestVersion;
+    });
+}
+exports.currentFirmwareVersion = currentFirmwareVersion;
+function revisionOfLastVersionBump(gitRepo, versionFilePath, productVersionMacroName) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const git = (0, simple_git_1.default)(gitRepo);
+        // Get the blame information for the version file
+        const blameInfo = yield git.raw(['blame', versionFilePath]);
+        // Use regex to find the line containing the PRODUCT_VERSION macro
+        const versionRegex = new RegExp(`^([a-f0-9]+).+${productVersionMacroName}.*\\(\\d+\\)`, 'm');
+        const match = versionRegex.exec(blameInfo);
+        if (match) {
+            const commitHash = match[1];
+            return commitHash;
+        }
+        else {
+            throw new Error(`Could not find the ${productVersionMacroName} line in the blame information.`);
+        }
+    });
+}
+exports.revisionOfLastVersionBump = revisionOfLastVersionBump;
+function findProductVersionMacroFile(gitRepo, productVersionMacroName) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const files = yield (0, promises_1.readdir)(gitRepo);
+        for (const file of files) {
+            const fullPath = (0, path_1.join)(gitRepo, file);
+            const fileStat = yield (0, promises_1.stat)(fullPath);
+            if (fileStat.isDirectory()) {
+                if (file.startsWith('.')) {
+                    continue;
+                }
+                try {
+                    return yield findProductVersionMacroFile(fullPath, productVersionMacroName);
+                }
+                catch (error) {
+                    // Ignore. It means the file was not found in this directory.
+                }
+            }
+            else {
+                const fileContent = yield (0, promises_1.readFile)(fullPath, 'utf-8');
+                const versionRegex = new RegExp(`^.*${productVersionMacroName}.*\\((\\d+)\\)`, 'gm');
+                if (fileContent && versionRegex.test(fileContent)) {
+                    return fullPath;
+                }
+            }
+        }
+        throw new Error(`Could not find a file containing the ${productVersionMacroName} macro.`);
+    });
+}
+exports.findProductVersionMacroFile = findProductVersionMacroFile;
+function findNearestGitRoot(startingPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const git = (0, simple_git_1.default)(startingPath);
+        try {
+            const gitRoot = yield git.revparse(['--show-toplevel']);
+            return gitRoot.trim();
+        }
+        catch (error) {
+            const parentPath = (0, path_1.dirname)(startingPath);
+            if (parentPath === startingPath) {
+                throw new Error('No Git repository found in the parent directories');
+            }
+            return yield findNearestGitRoot(parentPath);
+        }
+    });
+}
+exports.findNearestGitRoot = findNearestGitRoot;
+function mostRecentRevisionInFolder(gitRepo, folderPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const git = (0, simple_git_1.default)(gitRepo);
+        try {
+            const log = yield git.log({ file: folderPath });
+            if (!log.latest) {
+                throw new Error('No latest revision found');
+            }
+            return log.latest.hash.substring(0, 8);
+        }
+        catch (error) {
+            throw new Error(`Error getting the latest Git revision for folder "${folderPath}": ${error}`);
+        }
+    });
+}
+exports.mostRecentRevisionInFolder = mostRecentRevisionInFolder;
 
 
 /***/ }),
@@ -29625,6 +34150,95 @@ exports._resetFirmwareManifest = _resetFirmwareManifest;
 
 /***/ }),
 
+/***/ 5622:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+// Auto revision assumes the PRODUCT_VERSION macro is only incremented and not decremented.
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.isProductFirmware = exports.incrementVersion = exports.shouldIncrementVersion = void 0;
+const promises_1 = __nccwpck_require__(3292);
+const core_1 = __nccwpck_require__(2186);
+const git_1 = __nccwpck_require__(6350);
+function shouldIncrementVersion({ gitRepo, sources, productVersionMacroName }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const versionFilePath = yield (0, git_1.findProductVersionMacroFile)(sources, productVersionMacroName);
+        if (!versionFilePath) {
+            throw new Error('Could not find a file containing the version macro.');
+        }
+        const lastChangeRevision = yield (0, git_1.revisionOfLastVersionBump)(gitRepo, versionFilePath, productVersionMacroName);
+        const currentSourcesRevision = yield (0, git_1.mostRecentRevisionInFolder)(gitRepo, sources);
+        const currentProductVersion = yield (0, git_1.currentFirmwareVersion)(gitRepo, versionFilePath, productVersionMacroName);
+        if (!lastChangeRevision) {
+            throw new Error('Could not find the last version increment.');
+        }
+        (0, core_1.info)(`Current firmware version: ${currentProductVersion} (${currentSourcesRevision})`);
+        (0, core_1.info)(`Firmware version last set at: ${lastChangeRevision}`);
+        if (lastChangeRevision === '00000000') {
+            (0, core_1.warning)('The file with the product version macro has uncommitted changes.');
+        }
+        const shouldIncrement = currentSourcesRevision !== lastChangeRevision;
+        if (!shouldIncrement) {
+            (0, core_1.info)('No version increment detected. Skipping version increment.');
+            return false;
+        }
+        (0, core_1.info)(`Incrementing firmware version to ${currentProductVersion + 1}.`);
+        return true;
+    });
+}
+exports.shouldIncrementVersion = shouldIncrementVersion;
+function incrementVersion({ gitRepo, sources, productVersionMacroName }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // find the file containing the version macro
+        const versionFilePath = yield (0, git_1.findProductVersionMacroFile)(sources, productVersionMacroName);
+        // get the current version
+        const current = yield (0, git_1.currentFirmwareVersion)(gitRepo, versionFilePath, productVersionMacroName);
+        // increment the version
+        const next = current + 1;
+        // find the line that matches this regex
+        const versionRegex = new RegExp(`^.*${productVersionMacroName}.*\\((\\d+)\\)`, 'gm');
+        // Read the file content
+        const fileContent = yield (0, promises_1.readFile)(versionFilePath, 'utf-8');
+        // Replace the version with the next version
+        const updatedFileContent = fileContent.replace(versionRegex, (match, p1) => {
+            (0, core_1.info)(`Replacing ${p1} with ${next} in ${versionFilePath}`);
+            return match.replace(p1, next.toString());
+        });
+        yield (0, promises_1.writeFile)(versionFilePath, updatedFileContent);
+        return {
+            file: versionFilePath,
+            version: next
+        };
+    });
+}
+exports.incrementVersion = incrementVersion;
+function isProductFirmware({ sources, productVersionMacroName }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let isProductFirmware = false;
+        try {
+            isProductFirmware = !!(yield (0, git_1.findProductVersionMacroFile)(sources, productVersionMacroName));
+        }
+        catch (error) {
+            // Ignore
+        }
+        return isProductFirmware;
+    });
+}
+exports.isProductFirmware = isProductFirmware;
+
+
+/***/ }),
+
 /***/ 9491:
 /***/ ((module) => {
 
@@ -29670,6 +34284,14 @@ module.exports = require("events");
 
 "use strict";
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 3292:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("fs/promises");
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -34034,7 +34034,7 @@ function particleDownloadBinary({ binaryId, auth }) {
                 (0, fs_1.mkdirSync)(destDir);
             }
             (0, fs_1.writeFileSync)(`${outputPath}`, resp, 'utf8');
-            (0, core_1.info)(`File written to ${outputPath} successfully.`);
+            (0, core_1.info)(`File downloaded successfully.`);
             return outputPath;
         }
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -33607,9 +33607,13 @@ function autoVersion({ sources, gitRepo, autoVersionEnabled, versionMacroName })
         let autoVersionNext;
         let incremented = false;
         if (autoVersionEnabled) {
+            const validGitRepo = yield (0, git_1.hasFullHistory)({ gitRepo });
             const productFirmware = yield (0, versioning_1.isProductFirmware)({
                 sources, productVersionMacroName: versionMacroName
             });
+            if (!validGitRepo) {
+                throw new Error('Auto-versioning is enabled, but the git repository does not appear to have a full history. Try setting `fetch-depth: 0` on `actions/checkout` to fetch all history for all branches and tags.');
+            }
             if (!productFirmware) {
                 throw new Error('Auto-versioning is enabled, but the firmware does not appear to be a product firmware. The version macro could not be found. Please disable auto-versioning or specify the correct macro name.');
             }
@@ -33795,7 +33799,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.mostRecentRevisionInFolder = exports.findNearestGitRoot = exports.findProductVersionMacroFile = exports.revisionOfLastVersionBump = exports.currentFirmwareVersion = void 0;
+exports.hasFullHistory = exports.mostRecentRevisionInFolder = exports.findNearestGitRoot = exports.findProductVersionMacroFile = exports.revisionOfLastVersionBump = exports.currentFirmwareVersion = void 0;
 const promises_1 = __nccwpck_require__(3292);
 const path_1 = __nccwpck_require__(1017);
 const simple_git_1 = __importDefault(__nccwpck_require__(9103));
@@ -33914,6 +33918,14 @@ function mostRecentRevisionInFolder({ gitRepo, folderPath }) {
     });
 }
 exports.mostRecentRevisionInFolder = mostRecentRevisionInFolder;
+function hasFullHistory({ gitRepo }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const git = (0, simple_git_1.default)(gitRepo);
+        const isShallow = yield git.raw(['rev-parse', '--is-shallow-repository']);
+        return isShallow.trim() === 'false';
+    });
+}
+exports.hasFullHistory = hasFullHistory;
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -33595,10 +33595,11 @@ function resolveInputs() {
         return { auth, platform, sources, autoVersionEnabled, versionMacroName, targetVersion };
     });
 }
-function setOutputs({ artifactPath, deviceOsVersion, firmwareVersion }) {
+function setOutputs({ artifactPath, deviceOsVersion, firmwareVersion, firmwareVersionUpdated }) {
     (0, core_1.setOutput)('artifact-path', artifactPath);
     (0, core_1.setOutput)('device-os-version', deviceOsVersion);
     (0, core_1.setOutput)('firmware-version', firmwareVersion);
+    (0, core_1.setOutput)('firmware-version-updated', firmwareVersionUpdated);
 }
 function autoVersion({ sources, gitRepo, autoVersionEnabled, versionMacroName }) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -33665,7 +33666,7 @@ function compileAction() {
         try {
             const { auth, platform, sources, autoVersionEnabled, versionMacroName, targetVersion } = yield resolveInputs();
             const gitRepo = yield (0, git_1.findNearestGitRoot)({ startingPath: sources });
-            const { autoVersionNext } = yield autoVersion({
+            const { autoVersionNext, incremented } = yield autoVersion({
                 sources, gitRepo, autoVersionEnabled, versionMacroName
             });
             const { outputPath } = yield compile({ auth, platform, sources, targetVersion });
@@ -33673,7 +33674,8 @@ function compileAction() {
                 setOutputs({
                     artifactPath: outputPath,
                     deviceOsVersion: targetVersion,
-                    firmwareVersion: autoVersionNext
+                    firmwareVersion: autoVersionNext,
+                    firmwareVersionUpdated: incremented
                 });
             }
             else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -33692,8 +33692,13 @@ function compileAction() {
             });
             const { outputPath } = yield compile({ auth, platform, sources, targetVersion });
             if (outputPath) {
+                const artifactPath = (0, util_1.renameFile)({
+                    filePath: outputPath,
+                    platform,
+                    version: targetVersion
+                });
                 setOutputs({
-                    artifactPath: outputPath,
+                    artifactPath: artifactPath,
                     deviceOsVersion: targetVersion,
                     firmwareVersion: version,
                     firmwareVersionUpdated: incremented
@@ -34080,13 +34085,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports._resetFirmwareManifest = exports.resolveVersion = exports.fetchFirmwareManifest = exports.validatePlatformDeviceOsTarget = exports.validatePlatformName = exports.getPlatformId = exports.getCode = void 0;
+exports._resetFirmwareManifest = exports.renameFile = exports.resolveVersion = exports.fetchFirmwareManifest = exports.validatePlatformDeviceOsTarget = exports.validatePlatformName = exports.getPlatformId = exports.getCode = void 0;
 const cli_1 = __nccwpck_require__(6815);
 const fs_1 = __nccwpck_require__(7147);
 // @ts-ignore
 const device_constants_1 = __importDefault(__nccwpck_require__(9452));
 const httpm = __importStar(__nccwpck_require__(6255));
 const semver_1 = __nccwpck_require__(1383);
+const path_1 = __nccwpck_require__(1017);
 function getCode(path) {
     if (!(0, fs_1.existsSync)(path)) {
         throw new Error(`Source code ${path} does not exist`);
@@ -34188,6 +34194,14 @@ function resolveVersion(platform, version) {
     });
 }
 exports.resolveVersion = resolveVersion;
+function renameFile({ filePath, platform, version }) {
+    const dir = (0, path_1.dirname)(filePath);
+    const newFileName = `firmware-${platform}-${version}.bin`;
+    const newFilePath = (0, path_1.join)(dir, newFileName);
+    (0, fs_1.renameSync)(filePath, newFilePath);
+    return newFilePath;
+}
+exports.renameFile = renameFile;
 // For testing
 function _resetFirmwareManifest() {
     // @ts-ignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "execa": "^5.0.0",
         "glob": "^7.2.3",
         "particle-api-js": "^9.4.1",
-        "semver": "^7.3.8"
+        "semver": "^7.3.8",
+        "simple-git": "^3.17.0"
       },
       "devDependencies": {
         "@types/jest": "^27.5.2",
@@ -1142,6 +1143,19 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6095,6 +6109,20 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
+    "node_modules/simple-git": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
+      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7890,6 +7918,19 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
+    "@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -11554,6 +11595,16 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "simple-git": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
+      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
+      "requires": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.4"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "execa": "^5.0.0",
     "glob": "^7.2.3",
     "particle-api-js": "^9.4.1",
-    "semver": "^7.3.8"
+    "semver": "^7.3.8",
+    "simple-git": "^3.17.0"
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -28,11 +28,13 @@ jest.mock('@actions/core', () => ({
 const findProductVersionMacroFileMock = jest.fn();
 const currentFirmwareVersionMock = jest.fn();
 const findNearestGitRootMock = jest.fn();
+const hasFullHistoryMock = jest.fn();
 jest.mock('./git', () => {
 	return {
 		findProductVersionMacroFile: findProductVersionMacroFileMock,
 		currentFirmwareVersion: currentFirmwareVersionMock,
-		findNearestGitRoot: findNearestGitRootMock
+		findNearestGitRoot: findNearestGitRootMock,
+		hasFullHistory: hasFullHistoryMock
 	};
 });
 
@@ -110,6 +112,7 @@ describe('autoVersion', () => {
 		};
 		const { autoVersion } = await import('./action');
 
+		hasFullHistoryMock.mockResolvedValue(true);
 		isProductFirmwareMock.mockResolvedValue(false);
 
 		await expect(autoVersion(params)).rejects.toThrow(
@@ -126,6 +129,7 @@ describe('autoVersion', () => {
 		};
 		const { autoVersion } = await import('./action');
 
+		hasFullHistoryMock.mockResolvedValue(true);
 		isProductFirmwareMock.mockResolvedValue(true);
 		findProductVersionMacroFileMock.mockResolvedValue('/path/to/repo/src/application.cpp');
 		currentFirmwareVersionMock.mockResolvedValue(1);
@@ -157,6 +161,7 @@ describe('autoVersion', () => {
 		};
 		const { autoVersion } = await import('./action');
 
+		hasFullHistoryMock.mockResolvedValue(true);
 		isProductFirmwareMock.mockResolvedValue(true);
 		findProductVersionMacroFileMock.mockResolvedValue('/path/to/repo/src/application.cpp');
 		currentFirmwareVersionMock.mockResolvedValue(1);
@@ -186,6 +191,7 @@ describe('autoVersion', () => {
 
 		const result = await autoVersion(params);
 
+		hasFullHistoryMock.mockResolvedValue(true);
 		expect(isProductFirmwareMock).not.toHaveBeenCalled();
 		expect(findProductVersionMacroFileMock).not.toHaveBeenCalled();
 		expect(currentFirmwareVersionMock).not.toHaveBeenCalled();

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -146,8 +146,8 @@ describe('autoVersion', () => {
 		expect(currentFirmwareVersionMock).toHaveBeenCalled();
 		expect(shouldIncrementVersionMock).toHaveBeenCalled();
 		expect(result).toEqual({
-			autoVersionFile: '/path/to/repo/src/application.cpp',
-			autoVersionNext: 2,
+			versionFile: '/path/to/repo/src/application.cpp',
+			version: 2,
 			incremented: true
 		});
 	});
@@ -174,13 +174,13 @@ describe('autoVersion', () => {
 		expect(currentFirmwareVersionMock).toHaveBeenCalled();
 		expect(shouldIncrementVersionMock).toHaveBeenCalled();
 		expect(result).toEqual({
-			autoVersionFile: '/path/to/repo/src/application.cpp',
-			autoVersionNext: 1,
+			versionFile: '/path/to/repo/src/application.cpp',
+			version: 1,
 			incremented: false
 		});
 	});
 
-	test('should return an empty result if auto-versioning is disabled', async () => {
+	test('should check firmware version if auto-versioning is disabled', async () => {
 		const params = {
 			sources: '/path/to/sources',
 			gitRepo: '/path/to/repo',
@@ -189,16 +189,18 @@ describe('autoVersion', () => {
 		};
 		const { autoVersion } = await import('./action');
 
+		currentFirmwareVersionMock.mockResolvedValue(1);
+
 		const result = await autoVersion(params);
 
 		hasFullHistoryMock.mockResolvedValue(true);
 		expect(isProductFirmwareMock).not.toHaveBeenCalled();
-		expect(findProductVersionMacroFileMock).not.toHaveBeenCalled();
-		expect(currentFirmwareVersionMock).not.toHaveBeenCalled();
+		expect(findProductVersionMacroFileMock).toHaveBeenCalled();
+		expect(currentFirmwareVersionMock).toHaveBeenCalled();
 		expect(shouldIncrementVersionMock).not.toHaveBeenCalled();
 		expect(result).toEqual({
-			autoVersionFile: undefined,
-			autoVersionNext: undefined,
+			versionFile: undefined,
+			version: 1,
 			incremented: false
 		});
 	});

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -1,81 +1,199 @@
+jest.mock('./util');
+
+const dockerCheckMock = jest.fn();
+const dockerBuildpackCompileMock = jest.fn();
+jest.mock('./docker', () => ({
+	dockerCheck: dockerCheckMock,
+	dockerBuildpackCompile: dockerBuildpackCompileMock
+}));
+
+const particleCloudCompileMock = jest.fn();
+const particleDownloadBinaryMock = jest.fn();
+jest.mock('./particle-api', () => ({
+	particleCloudCompile: particleCloudCompileMock,
+	particleDownloadBinary: particleDownloadBinaryMock
+}));
+
+const getInputMock = jest.fn();
+const setFailedMock = jest.fn();
+const infoMock = jest.fn();
+const setOutputMock = jest.fn();
+jest.mock('@actions/core', () => ({
+	getInput: getInputMock,
+	setFailed: setFailedMock,
+	info: infoMock,
+	setOutput: setOutputMock
+}));
+
+const findProductVersionMacroFileMock = jest.fn();
+const currentFirmwareVersionMock = jest.fn();
+const findNearestGitRootMock = jest.fn();
+jest.mock('./git', () => {
+	return {
+		findProductVersionMacroFile: findProductVersionMacroFileMock,
+		currentFirmwareVersion: currentFirmwareVersionMock,
+		findNearestGitRoot: findNearestGitRootMock
+	};
+});
+
+const isProductFirmwareMock = jest.fn();
+const shouldIncrementVersionMock = jest.fn();
+const incrementVersionMock = jest.fn();
+jest.mock('./versioning', () => {
+	return {
+		isProductFirmware: isProductFirmwareMock,
+		shouldIncrementVersion: shouldIncrementVersionMock,
+		incrementVersion: incrementVersionMock
+	};
+});
+
+import { compileAction } from './action';
+
 describe('compileAction', () => {
 
-	afterEach(() => {
+	beforeEach(() => {
 		jest.resetModules();
 	});
 
 	it('should use compile locally with docker by default', async () => {
-		const dockerCheckMock = jest.fn();
-		const dockerBuildpackCompileMock = jest.fn();
-		jest.mock('./util', () => ({
-			resolveVersion: jest.fn(),
-			validatePlatformName: jest.fn(),
-			validatePlatformDeviceOsTarget: jest.fn()
-		}));
-		jest.mock('./docker', () => ({
-			dockerCheck: dockerCheckMock,
-			dockerBuildpackCompile: dockerBuildpackCompileMock
-		}));
-		const { compileAction } = await import('./action');
 		await compileAction();
+
 		expect(dockerCheckMock).toHaveBeenCalled();
 		expect(dockerBuildpackCompileMock).toHaveBeenCalled();
 	});
 
 	it('should use compile in the cloud if access token is provided', async () => {
-		jest.mock('./util', () => ({
-			resolveVersion: jest.fn(),
-			validatePlatformName: jest.fn(),
-			validatePlatformDeviceOsTarget: jest.fn()
-		}));
 		// mock particle-access-token input
-		jest.mock('@actions/core', () => ({
-			getInput: jest.fn().mockImplementation((name: string) => {
-				if (name === 'particle-access-token') {
-					return 'test-token';
-				}
-				return '';
-			}),
-			setFailed: jest.fn(),
-			info: jest.fn(),
-			setOutput: jest.fn()
-		}));
+		getInputMock.mockImplementation((name: string) => {
+			if (name === 'particle-access-token') {
+				return 'test-token';
+			}
+			return '';
+		});
+		particleCloudCompileMock.mockResolvedValue('test-binary-id');
+		particleDownloadBinaryMock.mockResolvedValue('test-path');
 
-		const particleCloudCompileMock = jest.fn().mockResolvedValue('test-binary-id');
-		const particleDownloadBinaryMock = jest.fn().mockResolvedValue('test-path');
-		jest.mock('./particle-api', () => ({
-			particleCloudCompile: particleCloudCompileMock,
-			particleDownloadBinary: particleDownloadBinaryMock
-		}));
-		const { compileAction } = await import('./action');
 		await compileAction();
+
 		expect(particleCloudCompileMock).toHaveBeenCalled();
 		expect(particleDownloadBinaryMock).toHaveBeenCalled();
 	});
 
 	it('should throw an error if cloud compilation fails', async () => {
 		// mock particle-access-token input
-		const setFailedMock = jest.fn();
-		jest.mock('@actions/core', () => ({
-			getInput: jest.fn().mockImplementation((name: string) => {
-				if (name === 'particle-access-token') {
-					return 'test-token';
-				}
-				return '';
-			}),
-			setFailed: setFailedMock,
-			info: jest.fn(),
-			setOutput: jest.fn()
-		}));
+		getInputMock.mockImplementation((name: string) => {
+			if (name === 'particle-access-token') {
+				return 'test-token';
+			}
+			return '';
+		});
+		particleCloudCompileMock.mockResolvedValue(null);
 
-		const particleCloudCompileMock = jest.fn().mockResolvedValue(null);
-		jest.mock('./particle-api', () => ({
-			particleCloudCompile: particleCloudCompileMock
-		}));
-		const { compileAction } = await import('./action');
 		await compileAction();
+
 		expect(setFailedMock).toHaveBeenCalled();
 		expect(setFailedMock).toHaveBeenCalledWith('Failed to compile code in cloud');
 	});
+});
 
+describe('autoVersion', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	test('should throw an error if auto-versioning is enabled and firmware is not a product firmware', async () => {
+		const params = {
+			sources: '/path/to/repo/src',
+			gitRepo: '/path/to/repo',
+			autoVersionEnabled: true,
+			versionMacroName: 'PRODUCT_VERSION'
+		};
+		const { autoVersion } = await import('./action');
+
+		isProductFirmwareMock.mockResolvedValue(false);
+
+		await expect(autoVersion(params)).rejects.toThrow(
+			'Auto-versioning is enabled, but the firmware does not appear to be a product firmware.'
+		);
+	});
+
+	test('should increment the firmware version if auto-versioning is enabled and shouldIncrementVersion returns true', async () => {
+		const params = {
+			sources: '/path/to/repo/src',
+			gitRepo: '/path/to/repo',
+			autoVersionEnabled: true,
+			versionMacroName: 'PRODUCT_VERSION'
+		};
+		const { autoVersion } = await import('./action');
+
+		isProductFirmwareMock.mockResolvedValue(true);
+		findProductVersionMacroFileMock.mockResolvedValue('/path/to/repo/src/application.cpp');
+		currentFirmwareVersionMock.mockResolvedValue(1);
+		shouldIncrementVersionMock.mockResolvedValue(true);
+		incrementVersionMock.mockResolvedValue({
+			file: '/path/to/repo/src/application.cpp',
+			version: 2
+		});
+
+		const result = await autoVersion(params);
+
+		expect(isProductFirmwareMock).toHaveBeenCalled();
+		expect(findProductVersionMacroFileMock).toHaveBeenCalled();
+		expect(currentFirmwareVersionMock).toHaveBeenCalled();
+		expect(shouldIncrementVersionMock).toHaveBeenCalled();
+		expect(result).toEqual({
+			autoVersionFile: '/path/to/repo/src/application.cpp',
+			autoVersionNext: 2,
+			incremented: true
+		});
+	});
+
+	test('should not increment the firmware version if auto-versioning is enabled and shouldIncrementVersion returns false', async () => {
+		const params = {
+			sources: '/path/to/repo/src',
+			gitRepo: '/path/to/repo',
+			autoVersionEnabled: true,
+			versionMacroName: 'PRODUCT_VERSION'
+		};
+		const { autoVersion } = await import('./action');
+
+		isProductFirmwareMock.mockResolvedValue(true);
+		findProductVersionMacroFileMock.mockResolvedValue('/path/to/repo/src/application.cpp');
+		currentFirmwareVersionMock.mockResolvedValue(1);
+		shouldIncrementVersionMock.mockResolvedValue(false);
+
+		const result = await autoVersion(params);
+
+		expect(isProductFirmwareMock).toHaveBeenCalled();
+		expect(findProductVersionMacroFileMock).toHaveBeenCalled();
+		expect(currentFirmwareVersionMock).toHaveBeenCalled();
+		expect(shouldIncrementVersionMock).toHaveBeenCalled();
+		expect(result).toEqual({
+			autoVersionFile: '/path/to/repo/src/application.cpp',
+			autoVersionNext: 1,
+			incremented: false
+		});
+	});
+
+	test('should return an empty result if auto-versioning is disabled', async () => {
+		const params = {
+			sources: '/path/to/sources',
+			gitRepo: '/path/to/repo',
+			autoVersionEnabled: false,
+			versionMacroName: 'PRODUCT_VERSION'
+		};
+		const { autoVersion } = await import('./action');
+
+		const result = await autoVersion(params);
+
+		expect(isProductFirmwareMock).not.toHaveBeenCalled();
+		expect(findProductVersionMacroFileMock).not.toHaveBeenCalled();
+		expect(currentFirmwareVersionMock).not.toHaveBeenCalled();
+		expect(shouldIncrementVersionMock).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			autoVersionFile: undefined,
+			autoVersionNext: undefined,
+			incremented: false
+		});
+	});
 });

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,4 +1,4 @@
-import { getInput, info, setFailed, setOutput, warning } from '@actions/core';
+import { getInput, info, setFailed, setOutput } from '@actions/core';
 import { dockerBuildpackCompile, dockerCheck } from './docker';
 import { particleCloudCompile, particleDownloadBinary } from './particle-api';
 import { resolveVersion, validatePlatformDeviceOsTarget, validatePlatformName } from './util';

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,7 +1,7 @@
 import { getInput, info, setFailed, setOutput } from '@actions/core';
 import { dockerBuildpackCompile, dockerCheck } from './docker';
 import { particleCloudCompile, particleDownloadBinary } from './particle-api';
-import { resolveVersion, validatePlatformDeviceOsTarget, validatePlatformName } from './util';
+import { renameFile, resolveVersion, validatePlatformDeviceOsTarget, validatePlatformName } from './util';
 import { incrementVersion, isProductFirmware, shouldIncrementVersion } from './versioning';
 import { currentFirmwareVersion, findNearestGitRoot, findProductVersionMacroFile, hasFullHistory } from './git';
 
@@ -157,8 +157,14 @@ export async function compileAction(): Promise<void> {
 		);
 
 		if (outputPath) {
+			const artifactPath = renameFile({
+				filePath: outputPath,
+				platform,
+				version: targetVersion
+			});
+
 			setOutputs({
-				artifactPath: outputPath,
+				artifactPath: artifactPath,
 				deviceOsVersion: targetVersion,
 				firmwareVersion: version,
 				firmwareVersionUpdated: incremented

--- a/src/action.ts
+++ b/src/action.ts
@@ -18,6 +18,7 @@ interface ActionOutputs {
 	artifactPath: string;
 	deviceOsVersion: string;
 	firmwareVersion: number | undefined;
+	firmwareVersionUpdated: boolean;
 }
 
 async function resolveInputs(): Promise<ActionInputs> {
@@ -38,11 +39,12 @@ async function resolveInputs(): Promise<ActionInputs> {
 }
 
 function setOutputs(
-	{ artifactPath, deviceOsVersion, firmwareVersion }: ActionOutputs
+	{ artifactPath, deviceOsVersion, firmwareVersion, firmwareVersionUpdated }: ActionOutputs
 ): void {
 	setOutput('artifact-path', artifactPath);
 	setOutput('device-os-version', deviceOsVersion);
 	setOutput('firmware-version', firmwareVersion);
+	setOutput('firmware-version-updated', firmwareVersionUpdated);
 }
 
 export async function autoVersion(
@@ -126,7 +128,7 @@ export async function compileAction(): Promise<void> {
 		const { auth, platform, sources, autoVersionEnabled, versionMacroName, targetVersion } = await resolveInputs();
 
 		const gitRepo = await findNearestGitRoot({ startingPath: sources });
-		const { autoVersionNext } = await autoVersion({
+		const { autoVersionNext, incremented } = await autoVersion({
 			sources, gitRepo, autoVersionEnabled, versionMacroName
 		});
 
@@ -138,7 +140,8 @@ export async function compileAction(): Promise<void> {
 			setOutputs({
 				artifactPath: outputPath,
 				deviceOsVersion: targetVersion,
-				firmwareVersion: autoVersionNext
+				firmwareVersion: autoVersionNext,
+				firmwareVersionUpdated: incremented
 			});
 		} else {
 			setFailed(`Failed to compile code in '${sources}'`);

--- a/src/action.ts
+++ b/src/action.ts
@@ -2,36 +2,129 @@ import { getInput, info, setFailed, setOutput } from '@actions/core';
 import { dockerBuildpackCompile, dockerCheck } from './docker';
 import { particleCloudCompile, particleDownloadBinary } from './particle-api';
 import { resolveVersion, validatePlatformDeviceOsTarget, validatePlatformName } from './util';
+import { incrementVersion, isProductFirmware, shouldIncrementVersion } from './versioning';
+import { currentFirmwareVersion, findNearestGitRoot, findProductVersionMacroFile } from './git';
+
+interface ActionInputs {
+	auth: string;
+	platform: string;
+	sources: string;
+	autoVersionEnabled: boolean;
+	versionMacroName: string;
+	targetVersion: string;
+}
+
+async function resolveInputs(): Promise<ActionInputs> {
+	const auth: string = getInput('particle-access-token');
+	const platform: string = getInput('particle-platform-name');
+	const version: string = getInput('device-os-version');
+	const sources: string = getInput('sources-folder');
+	const autoVersionEnabled: boolean = getInput('auto-version') === 'true';
+	const versionMacroName: string = getInput('auto-version-macro-name');
+
+	validatePlatformName(platform);
+
+	const targetVersion = await resolveVersion(platform, version);
+
+	await validatePlatformDeviceOsTarget(platform, targetVersion);
+
+	return { auth, platform, sources, autoVersionEnabled, versionMacroName, targetVersion };
+}
+
+interface AutoVersionParams {
+	sources: string;
+	gitRepo: string;
+	autoVersionEnabled: boolean;
+	versionMacroName: string;
+}
+
+interface AutoVersionResult {
+	autoVersionFile: string | undefined;
+	autoVersionNext: number | undefined;
+	incremented: boolean;
+}
+
+export async function autoVersion(
+	{ sources, gitRepo, autoVersionEnabled, versionMacroName }: AutoVersionParams
+): Promise<AutoVersionResult> {
+	let autoVersionFile: string | undefined;
+	let autoVersionNext: number | undefined;
+	let incremented = false;
+	if (autoVersionEnabled) {
+		const productFirmware = await isProductFirmware({
+			sources, productVersionMacroName: versionMacroName
+		});
+		if (!productFirmware) {
+			throw new Error('Auto-versioning is enabled, but the firmware does not appear to be a product firmware. The version macro could not be found. Please disable auto-versioning or specify the correct macro name.');
+		}
+		info('Auto-versioning is enabled, checking if firmware version should be incremented');
+		autoVersionFile = await findProductVersionMacroFile(sources, versionMacroName);
+		autoVersionNext = await currentFirmwareVersion(gitRepo, autoVersionFile, versionMacroName);
+
+		const shouldVersion = await shouldIncrementVersion({
+			gitRepo, sources, productVersionMacroName: versionMacroName
+		});
+		if (shouldVersion) {
+			const out = await incrementVersion({
+				gitRepo,
+				sources,
+				productVersionMacroName: versionMacroName
+			});
+			autoVersionNext = out.version;
+			autoVersionFile = out.file;
+			incremented = true;
+		}
+	}
+	return { autoVersionFile, autoVersionNext, incremented };
+}
+
+interface CompileParams {
+	auth: string;
+	platform: string;
+	sources: string;
+	targetVersion: string;
+}
+
+interface CompileResult {
+	outputPath: string | undefined;
+}
+
+export async function compile(
+	{ auth, platform, sources, targetVersion }: CompileParams
+): Promise<CompileResult> {
+	let outputPath: string | undefined;
+	if (!auth) {
+		info('No access token provided, running local compilation');
+		await dockerCheck();
+		outputPath = await dockerBuildpackCompile({ sources, platform, targetVersion, workingDir: process.cwd() });
+	} else {
+		info('Access token provided, running cloud compilation');
+		const binaryId = await particleCloudCompile({ sources, platform, targetVersion, auth });
+		if (!binaryId) {
+			throw new Error('Failed to compile code in cloud');
+		}
+		outputPath = await particleDownloadBinary({ binaryId, auth });
+	}
+	return { outputPath };
+}
 
 export async function compileAction(): Promise<void> {
 	try {
-		const auth: string = getInput('particle-access-token');
-		const platform: string = getInput('particle-platform-name');
-		const version: string = getInput('device-os-version');
-		const sources: string = getInput('sources-folder');
+		const { auth, platform, sources, autoVersionEnabled, versionMacroName, targetVersion } = await resolveInputs();
 
-		validatePlatformName(platform);
+		const gitRepo = await findNearestGitRoot(sources);
+		const { autoVersionNext } = await autoVersion({
+			sources, gitRepo, autoVersionEnabled, versionMacroName
+		});
 
-		const targetVersion = await resolveVersion(platform, version);
-		await validatePlatformDeviceOsTarget(platform, targetVersion);
-
-		let outputPath: string | undefined;
-		if (!auth) {
-			info('No access token provided, running local compilation');
-			await dockerCheck();
-			outputPath = await dockerBuildpackCompile({ sources, platform, targetVersion, workingDir: process.cwd() });
-		} else {
-			info('Access token provided, running cloud compilation');
-			const binaryId = await particleCloudCompile({ sources, platform, targetVersion, auth });
-			if (!binaryId) {
-				throw new Error('Failed to compile code in cloud');
-			}
-			outputPath = await particleDownloadBinary({ binaryId, auth });
-		}
+		const { outputPath } = await compile(
+			{ auth, platform, sources, targetVersion }
+		);
 
 		if (outputPath) {
 			setOutput('artifact-path', outputPath);
 			setOutput('device-os-version', targetVersion);
+			setOutput('firmware-version', autoVersionNext);
 		} else {
 			setFailed(`Failed to compile code in '${sources}'`);
 		}

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -16,15 +16,13 @@ export async function dockerCheck(): Promise<boolean> {
 	return true;
 }
 
-interface DockerBuildpackCompileParams {
-	workingDir: string;
-	sources: string;
-	platform: string;
-	targetVersion: string;
-}
-
 export async function dockerBuildpackCompile(
-	{ workingDir, sources, platform, targetVersion }: DockerBuildpackCompileParams
+	{ workingDir, sources, platform, targetVersion }: {
+		workingDir: string;
+		sources: string;
+		platform: string;
+		targetVersion: string;
+	}
 ): Promise<string> {
 	// Note: the buildpack only detects *.c and *.cpp files
 	// https://github.com/particle-iot/device-os/blob/196d497dd4c16ab83db6ea610cf2433047226a6a/user/build.mk#L64-L65

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,0 +1,286 @@
+import { readdir, readFile, stat } from 'fs/promises';
+import { Dirent } from 'fs';
+import {
+	currentFirmwareVersion, findNearestGitRoot,
+	findProductVersionMacroFile, mostRecentRevisionInFolder,
+	revisionOfLastVersionBump
+} from './git';
+
+jest.mock('simple-git');
+import simpleGit, { SimpleGit } from 'simple-git';
+
+const gitMock = simpleGit as jest.MockedFunction<typeof simpleGit>;
+
+jest.mock('fs/promises');
+const readdirMock = readdir as jest.MockedFunction<typeof readdir>;
+const statMock = stat as jest.MockedFunction<typeof stat>;
+const readFileMock = readFile as jest.MockedFunction<typeof readFile>;
+
+describe('revisionOfLastVersionBump', () => {
+	const rawMock = jest.fn();
+
+	const createBlameInfoMock = (commitHash: string, productVersionMacroName: string) => {
+		return `${commitHash} (Author 2023-04-07 12:34:56 +0000 1) ${productVersionMacroName}(5)`;
+	};
+
+	beforeEach(() => {
+		gitMock.mockReturnValue({ raw: rawMock } as unknown as SimpleGit);
+		rawMock.mockReset();
+	});
+
+	test('should return git revision from blame info', async () => {
+		const commitHash = 'a1b2c3d4e5f6';
+		const gitRepo = '/path/to/repo';
+		const versionFilePath = '/path/to/version/file/application.cpp';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+
+		rawMock.mockResolvedValue(createBlameInfoMock(commitHash, productVersionMacroName));
+
+		const result = await revisionOfLastVersionBump(gitRepo, versionFilePath, productVersionMacroName);
+
+		expect(result).toEqual(commitHash);
+		expect(gitMock).toHaveBeenCalledWith(gitRepo);
+		expect(rawMock).toHaveBeenCalledWith(['blame', versionFilePath]);
+	});
+
+	test('should throw error if product version macro name is not found', async () => {
+		const gitRepo = '/path/to/repo';
+		const versionFilePath = '/path/to/version/file/application.cpp';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+
+		rawMock.mockResolvedValue(`Different line content`);
+
+		await expect(revisionOfLastVersionBump(gitRepo, versionFilePath, productVersionMacroName)).rejects.toThrow(
+			`Could not find the ${productVersionMacroName} line in the blame information.`
+		);
+	});
+});
+
+describe('currentFirmwareVersion', () => {
+	const logMock = jest.fn();
+	const showMock = jest.fn();
+
+	const createCommitBodyMock = (productVersionMacroName: string, version: number) => {
+		return `${productVersionMacroName}(${version})`;
+	};
+
+	const createLogMock = (hashes: string[]) => {
+		return {
+			all: hashes.map(hash => ({ hash })),
+			total: hashes.length
+		};
+	};
+
+	beforeEach(() => {
+		gitMock.mockReturnValue({ log: logMock, show: showMock } as unknown as SimpleGit);
+		logMock.mockReset();
+		showMock.mockReset();
+	});
+
+	test('should return highest firmware version', async () => {
+		const commitHashes = ['a1b2c3d4e5f6', 'b2c3d4e5f6a1'];
+		const gitRepo = '/path/to/repo';
+		const versionFilePath = '/path/to/repo/project-folder/application.cpp';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+
+		logMock.mockResolvedValue(createLogMock(commitHashes));
+		showMock
+			.mockResolvedValueOnce(createCommitBodyMock(productVersionMacroName, 2))
+			.mockResolvedValueOnce(createCommitBodyMock(productVersionMacroName, 1));
+
+		const result = await currentFirmwareVersion(gitRepo, versionFilePath, productVersionMacroName);
+
+		expect(result).toBe(2);
+		expect(gitMock).toHaveBeenCalledWith(gitRepo);
+		expect(logMock).toHaveBeenCalledWith({
+			'-p': null,
+			'--': null,
+			file: versionFilePath
+		});
+		expect(showMock).toHaveBeenCalledTimes(2);
+		expect(showMock).toHaveBeenNthCalledWith(1, [`${commitHashes[0]}:project-folder/application.cpp`]);
+		expect(showMock).toHaveBeenNthCalledWith(2, [`${commitHashes[1]}:project-folder/application.cpp`]);
+	});
+
+	test('should return 0 if no version matches are found', async () => {
+		const commitHashes = ['a1b2c3d4e5f6', 'b2c3d4e5f6a1'];
+		const gitRepo = '/path/to/repo';
+		const versionFilePath = '/path/to/version/file/application.cpp';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+
+		logMock.mockResolvedValue(createLogMock(commitHashes));
+		showMock.mockResolvedValue(`Unrelated content`);
+
+		const result = await currentFirmwareVersion(gitRepo, versionFilePath, productVersionMacroName);
+
+		expect(result).toBe(0);
+	});
+});
+
+describe('findProductVersionMacroFile', () => {
+	beforeEach(() => {
+		readdirMock.mockReset();
+		statMock.mockReset();
+		readFileMock.mockReset();
+	});
+
+	test('should find the version macro file', async () => {
+		const gitRepo = '/path/to/repo';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+		const versionFilePath = '/path/to/repo/src/application.cpp';
+		const fileContent = `${productVersionMacroName}(1)`;
+
+		readdirMock
+			.mockResolvedValueOnce([
+				'.git',
+				'.gitignore',
+				'project.properties',
+				'readme.md',
+				'src' // mock directory
+			] as unknown as Dirent[])
+			.mockResolvedValueOnce([
+				'application.h',
+				'application.cpp',
+				'util.cpp'
+			] as unknown as Dirent[]);
+		// @ts-ignore
+		statMock.mockImplementation((file) => {
+			if (file === '/path/to/repo/src' || file === '/path/to/repo/.git') {
+				return Promise.resolve({ isDirectory: () => true });
+			}
+			return Promise.resolve({ isDirectory: () => false });
+		});
+		// @ts-ignore
+		readFileMock.mockImplementation((file) => {
+			return file === versionFilePath ? Promise.resolve(fileContent) : Promise.resolve(`Different content`);
+		});
+
+		const result = await findProductVersionMacroFile(gitRepo, productVersionMacroName);
+		expect(readdirMock).toHaveBeenCalledTimes(2);
+		expect(statMock).toHaveBeenCalledTimes(7);
+		expect(readFileMock).toHaveBeenCalledTimes(5);
+		expect(result).toBe(versionFilePath);
+	});
+
+	test('should throw an error if the version macro file is not found', async () => {
+		const sources = '/path/to/repo/src';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+
+		readdirMock.mockResolvedValue([
+			'file1',
+			'file2',
+			'file3'
+		] as unknown as Dirent[]);
+		// @ts-ignore
+		statMock.mockResolvedValue({ isDirectory: () => false });
+		readFileMock.mockResolvedValue(`Different content`);
+
+		await expect(findProductVersionMacroFile(sources, productVersionMacroName)).rejects.toThrow(
+			`Could not find a file containing the ${productVersionMacroName} macro.`
+		);
+	});
+});
+
+describe('findNearestGitRoot', () => {
+	const revparseMock = jest.fn();
+
+	beforeEach(() => {
+		gitMock.mockReturnValue({
+			revparse: revparseMock
+		} as unknown as SimpleGit);
+		jest.clearAllMocks();
+	});
+
+	test('should return the nearest Git root', async () => {
+		const startingPath = '/path/to/repo/some/subdirectory';
+		const gitRoot = '/path/to/repo';
+
+		// Set up the mock to return the Git root
+		revparseMock.mockResolvedValue(`${gitRoot}\n`);
+
+		const result = await findNearestGitRoot(startingPath);
+
+		expect(revparseMock).toHaveBeenCalledWith(['--show-toplevel']);
+		expect(result).toBe(gitRoot);
+	});
+
+	test('should search for Git root in parent directories', async () => {
+		const startingPath = '/path/to/repo/some/subdirectory';
+		const gitRoot = '/path/to/repo';
+
+		// Set up the mock to throw an error for the starting path and return the Git root for the parent path
+		revparseMock
+			.mockRejectedValueOnce(new Error('Not a Git repository'))
+			.mockResolvedValueOnce(`${gitRoot}\n`);
+
+		const result = await findNearestGitRoot(startingPath);
+
+		expect(revparseMock).toHaveBeenCalledTimes(2);
+		expect(result).toBe(gitRoot);
+	});
+
+	test('should throw an error if no Git repository is found in the parent directories', async () => {
+		const startingPath = '/path/to/non-git-folder';
+
+		// Set up the mock to throw an error
+		revparseMock.mockRejectedValue(new Error('Not a Git repository'));
+
+		await expect(findNearestGitRoot(startingPath)).rejects.toThrow(
+			'No Git repository found in the parent directories'
+		);
+	});
+});
+
+describe('mostRecentRevisionInFolder', () => {
+	const logMock = jest.fn();
+
+	beforeEach(() => {
+		gitMock.mockReturnValue({
+			log: logMock
+		} as unknown as SimpleGit);
+		jest.clearAllMocks();
+	});
+
+	test('should return the latest Git revision for a folder', async () => {
+		const gitRepo = '/path/to/repo';
+		const folderPath = '/path/to/repo/some/folder';
+		const latestHash = '123456789abcdef';
+
+		// Set up the mock to return the latest Git revision
+		logMock.mockResolvedValue({
+			latest: {
+				hash: latestHash
+			}
+		});
+
+		const result = await mostRecentRevisionInFolder(gitRepo, folderPath);
+
+		expect(logMock).toHaveBeenCalledWith({ file: folderPath });
+		expect(result).toBe(latestHash.substring(0, 8));
+	});
+
+	test('should throw an error if no latest revision is found', async () => {
+		const gitRepo = '/path/to/repo';
+		const folderPath = '/path/to/repo/some/folder';
+
+		// Set up the mock to return an empty log object
+		logMock.mockResolvedValue({});
+
+		await expect(mostRecentRevisionInFolder(gitRepo, folderPath)).rejects.toThrow(
+			'Error getting the latest Git revision for folder'
+		);
+	});
+
+	test('should throw an error if there is an error retrieving the Git log', async () => {
+		const gitRepo = '/path/to/repo';
+		const folderPath = '/path/to/repo/some/folder';
+
+		// Set up the mock to throw an error
+		logMock.mockRejectedValue(new Error('Error retrieving Git log'));
+
+		await expect(mostRecentRevisionInFolder(gitRepo, folderPath)).rejects.toThrow(
+			'Error getting the latest Git revision for folder'
+		);
+	});
+
+});

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -36,7 +36,11 @@ describe('revisionOfLastVersionBump', () => {
 
 		rawMock.mockResolvedValue(createBlameInfoMock(commitHash, productVersionMacroName));
 
-		const result = await revisionOfLastVersionBump(gitRepo, versionFilePath, productVersionMacroName);
+		const result = await revisionOfLastVersionBump({
+			gitRepo: gitRepo,
+			versionFilePath: versionFilePath,
+			productVersionMacroName: productVersionMacroName
+		});
 
 		expect(result).toEqual(commitHash);
 		expect(gitMock).toHaveBeenCalledWith(gitRepo);
@@ -50,7 +54,11 @@ describe('revisionOfLastVersionBump', () => {
 
 		rawMock.mockResolvedValue(`Different line content`);
 
-		await expect(revisionOfLastVersionBump(gitRepo, versionFilePath, productVersionMacroName)).rejects.toThrow(
+		await expect(revisionOfLastVersionBump({
+			gitRepo: gitRepo,
+			versionFilePath: versionFilePath,
+			productVersionMacroName: productVersionMacroName
+		})).rejects.toThrow(
 			`Could not find the ${productVersionMacroName} line in the blame information.`
 		);
 	});
@@ -88,7 +96,11 @@ describe('currentFirmwareVersion', () => {
 			.mockResolvedValueOnce(createCommitBodyMock(productVersionMacroName, 2))
 			.mockResolvedValueOnce(createCommitBodyMock(productVersionMacroName, 1));
 
-		const result = await currentFirmwareVersion(gitRepo, versionFilePath, productVersionMacroName);
+		const result = await currentFirmwareVersion({
+			gitRepo: gitRepo,
+			versionFilePath: versionFilePath,
+			productVersionMacroName: productVersionMacroName
+		});
 
 		expect(result).toBe(2);
 		expect(gitMock).toHaveBeenCalledWith(gitRepo);
@@ -111,7 +123,11 @@ describe('currentFirmwareVersion', () => {
 		logMock.mockResolvedValue(createLogMock(commitHashes));
 		showMock.mockResolvedValue(`Unrelated content`);
 
-		const result = await currentFirmwareVersion(gitRepo, versionFilePath, productVersionMacroName);
+		const result = await currentFirmwareVersion({
+			gitRepo: gitRepo,
+			versionFilePath: versionFilePath,
+			productVersionMacroName: productVersionMacroName
+		});
 
 		expect(result).toBe(0);
 	});
@@ -155,7 +171,10 @@ describe('findProductVersionMacroFile', () => {
 			return file === versionFilePath ? Promise.resolve(fileContent) : Promise.resolve(`Different content`);
 		});
 
-		const result = await findProductVersionMacroFile(gitRepo, productVersionMacroName);
+		const result = await findProductVersionMacroFile({
+			sources: gitRepo,
+			productVersionMacroName: productVersionMacroName
+		});
 		expect(readdirMock).toHaveBeenCalledTimes(2);
 		expect(statMock).toHaveBeenCalledTimes(7);
 		expect(readFileMock).toHaveBeenCalledTimes(5);
@@ -175,7 +194,9 @@ describe('findProductVersionMacroFile', () => {
 		statMock.mockResolvedValue({ isDirectory: () => false });
 		readFileMock.mockResolvedValue(`Different content`);
 
-		await expect(findProductVersionMacroFile(sources, productVersionMacroName)).rejects.toThrow(
+		await expect(findProductVersionMacroFile({
+			sources: sources, productVersionMacroName: productVersionMacroName
+		})).rejects.toThrow(
 			`Could not find a file containing the ${productVersionMacroName} macro.`
 		);
 	});
@@ -198,7 +219,7 @@ describe('findNearestGitRoot', () => {
 		// Set up the mock to return the Git root
 		revparseMock.mockResolvedValue(`${gitRoot}\n`);
 
-		const result = await findNearestGitRoot(startingPath);
+		const result = await findNearestGitRoot({ startingPath: startingPath });
 
 		expect(revparseMock).toHaveBeenCalledWith(['--show-toplevel']);
 		expect(result).toBe(gitRoot);
@@ -213,7 +234,7 @@ describe('findNearestGitRoot', () => {
 			.mockRejectedValueOnce(new Error('Not a Git repository'))
 			.mockResolvedValueOnce(`${gitRoot}\n`);
 
-		const result = await findNearestGitRoot(startingPath);
+		const result = await findNearestGitRoot({ startingPath: startingPath });
 
 		expect(revparseMock).toHaveBeenCalledTimes(2);
 		expect(result).toBe(gitRoot);
@@ -225,7 +246,7 @@ describe('findNearestGitRoot', () => {
 		// Set up the mock to throw an error
 		revparseMock.mockRejectedValue(new Error('Not a Git repository'));
 
-		await expect(findNearestGitRoot(startingPath)).rejects.toThrow(
+		await expect(findNearestGitRoot({ startingPath: startingPath })).rejects.toThrow(
 			'No Git repository found in the parent directories'
 		);
 	});
@@ -253,7 +274,7 @@ describe('mostRecentRevisionInFolder', () => {
 			}
 		});
 
-		const result = await mostRecentRevisionInFolder(gitRepo, folderPath);
+		const result = await mostRecentRevisionInFolder({ gitRepo: gitRepo, folderPath: folderPath });
 
 		expect(logMock).toHaveBeenCalledWith({ file: folderPath });
 		expect(result).toBe(latestHash.substring(0, 8));
@@ -266,7 +287,7 @@ describe('mostRecentRevisionInFolder', () => {
 		// Set up the mock to return an empty log object
 		logMock.mockResolvedValue({});
 
-		await expect(mostRecentRevisionInFolder(gitRepo, folderPath)).rejects.toThrow(
+		await expect(mostRecentRevisionInFolder({ gitRepo: gitRepo, folderPath: folderPath })).rejects.toThrow(
 			'Error getting the latest Git revision for folder'
 		);
 	});
@@ -278,7 +299,7 @@ describe('mostRecentRevisionInFolder', () => {
 		// Set up the mock to throw an error
 		logMock.mockRejectedValue(new Error('Error retrieving Git log'));
 
-		await expect(mostRecentRevisionInFolder(gitRepo, folderPath)).rejects.toThrow(
+		await expect(mostRecentRevisionInFolder({ gitRepo: gitRepo, folderPath: folderPath })).rejects.toThrow(
 			'Error getting the latest Git revision for folder'
 		);
 	});

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -2,7 +2,7 @@ import { readdir, readFile, stat } from 'fs/promises';
 import { Dirent } from 'fs';
 import {
 	currentFirmwareVersion, findNearestGitRoot,
-	findProductVersionMacroFile, mostRecentRevisionInFolder,
+	findProductVersionMacroFile, hasFullHistory, mostRecentRevisionInFolder,
 	revisionOfLastVersionBump
 } from './git';
 
@@ -302,6 +302,28 @@ describe('mostRecentRevisionInFolder', () => {
 		await expect(mostRecentRevisionInFolder({ gitRepo: gitRepo, folderPath: folderPath })).rejects.toThrow(
 			'Error getting the latest Git revision for folder'
 		);
+	});
+
+});
+describe('hasFullHistory', () => {
+	const gitRepo = '.'; // Use the current directory as the git repository for testing
+
+	it('should return true if the local repository has full history', async () => {
+		gitMock.mockReturnValue({
+			raw: jest.fn().mockResolvedValue('false')
+		} as unknown as SimpleGit);
+
+		const result = await hasFullHistory({ gitRepo: gitRepo });
+		expect(result).toBe(true);
+	});
+
+	it('should return false if the local repository does not have full history', async () => {
+		gitMock.mockReturnValue({
+			raw: jest.fn().mockResolvedValue('true')
+		} as unknown as SimpleGit);
+
+		const result = await hasFullHistory({ gitRepo: gitRepo });
+		expect(result).toBe(false);
 	});
 
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,130 @@
+import { readdir, readFile, stat } from 'fs/promises';
+import { dirname, join } from 'path';
+import simpleGit, { SimpleGit } from 'simple-git';
+
+export async function currentFirmwareVersion(
+	gitRepo: string,
+	versionFilePath: string,
+	productVersionMacroName: string
+): Promise<number> {
+	const git: SimpleGit = simpleGit(gitRepo);
+
+	// Get the commit history with patch details for the version file
+	const logs = await git.log({
+		'-p': null,
+		'--': null,
+		file: versionFilePath
+	});
+
+	let highestVersion = 0;
+
+	// if versionFilePath starts with gitRepo, remove it
+	if (versionFilePath.startsWith(gitRepo)) {
+		versionFilePath = versionFilePath.substring(gitRepo.length + 1);
+	}
+
+	for (const log of logs.all) {
+		const currentCommit = log.hash;
+		const commitBody = await git.show([`${currentCommit}:${versionFilePath}`]);
+
+		// Use regex to extract the PRODUCT_VERSION from the patch
+		const versionRegex = new RegExp(`^.*${productVersionMacroName}.*\\((\\d+)\\)`, 'gm');
+
+		const match = versionRegex.exec(commitBody);
+
+		if (match) {
+			const currentVersion = parseInt(match[1], 10);
+
+			// Check if the current version is higher than the previous version and higher than the highest version found
+			if (currentVersion > highestVersion) {
+				highestVersion = currentVersion;
+			}
+		}
+	}
+
+	return highestVersion;
+}
+
+export async function revisionOfLastVersionBump(
+	gitRepo: string,
+	versionFilePath: string,
+	productVersionMacroName: string
+): Promise<string> {
+	const git: SimpleGit = simpleGit(gitRepo);
+
+	// Get the blame information for the version file
+	const blameInfo = await git.raw(['blame', versionFilePath]);
+
+	// Use regex to find the line containing the PRODUCT_VERSION macro
+	const versionRegex = new RegExp(`^([a-f0-9]+).+${productVersionMacroName}.*\\(\\d+\\)`, 'm');
+	const match = versionRegex.exec(blameInfo);
+
+	if (match) {
+		const commitHash = match[1];
+		return commitHash;
+	} else {
+		throw new Error(`Could not find the ${productVersionMacroName} line in the blame information.`);
+	}
+}
+
+export async function findProductVersionMacroFile(
+	gitRepo: string,
+	productVersionMacroName: string
+): Promise<string> {
+	const files = await readdir(gitRepo);
+
+	for (const file of files) {
+		const fullPath = join(gitRepo, file);
+		const fileStat = await stat(fullPath);
+
+		if (fileStat.isDirectory()) {
+			if (file.startsWith('.')) {
+				continue;
+			}
+			try {
+				return await findProductVersionMacroFile(fullPath, productVersionMacroName);
+			} catch (error) {
+				// Ignore. It means the file was not found in this directory.
+			}
+		} else {
+			const fileContent = await readFile(fullPath, 'utf-8');
+			const versionRegex = new RegExp(`^.*${productVersionMacroName}.*\\((\\d+)\\)`, 'gm');
+			if (fileContent && versionRegex.test(fileContent)) {
+				return fullPath;
+			}
+		}
+	}
+
+	throw new Error(`Could not find a file containing the ${productVersionMacroName} macro.`);
+}
+
+export async function findNearestGitRoot(startingPath: string): Promise<string> {
+	const git: SimpleGit = simpleGit(startingPath);
+
+	try {
+		const gitRoot = await git.revparse(['--show-toplevel']);
+		return gitRoot.trim();
+	} catch (error) {
+		const parentPath = dirname(startingPath);
+
+		if (parentPath === startingPath) {
+			throw new Error('No Git repository found in the parent directories');
+		}
+
+		return await findNearestGitRoot(parentPath);
+	}
+}
+
+export async function mostRecentRevisionInFolder(gitRepo: string, folderPath: string): Promise<string> {
+	const git: SimpleGit = simpleGit(gitRepo);
+
+	try {
+		const log = await git.log({ file: folderPath });
+		if (!log.latest) {
+			throw new Error('No latest revision found');
+		}
+		return log.latest.hash.substring(0, 8);
+	} catch (error) {
+		throw new Error(`Error getting the latest Git revision for folder "${folderPath}": ${error}`);
+	}
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -138,3 +138,10 @@ export async function mostRecentRevisionInFolder(
 		throw new Error(`Error getting the latest Git revision for folder "${folderPath}": ${error}`);
 	}
 }
+
+export async function hasFullHistory({ gitRepo }: { gitRepo: string }): Promise<boolean> {
+	const git = simpleGit(gitRepo);
+	const isShallow = await git.raw(['rev-parse', '--is-shallow-repository']);
+
+	return isShallow.trim() === 'false';
+}

--- a/src/particle-api.ts
+++ b/src/particle-api.ts
@@ -80,7 +80,7 @@ export async function particleDownloadBinary(
 		}
 		writeFileSync(`${outputPath}`, resp, 'utf8');
 
-		info(`File written to ${outputPath} successfully.`);
+		info(`File downloaded successfully.`);
 		return outputPath;
 	}
 }

--- a/src/particle-api.ts
+++ b/src/particle-api.ts
@@ -6,15 +6,13 @@ import { getCode, getPlatformId } from './util';
 const ParticleApi = require('particle-api-js');
 const particle = new ParticleApi();
 
-interface ParticleCloudCompileParams {
-	sources: string;
-	platform: string;
-	auth: string;
-	targetVersion: string;
-}
-
 export async function particleCloudCompile(
-	{ sources, platform, auth, targetVersion }: ParticleCloudCompileParams
+	{ sources, platform, auth, targetVersion }: {
+		sources: string;
+		platform: string;
+		auth: string;
+		targetVersion: string;
+	}
 ): Promise<string> {
 	info(`Compiling code in '${sources}' for platform '${platform}' with target version '${targetVersion}'`);
 	if (!sources) {
@@ -58,13 +56,11 @@ export async function particleCloudCompile(
 	return binaryId;
 }
 
-interface ParticleDownloadBinaryParams {
-	binaryId: string;
-	auth: string;
-}
-
 export async function particleDownloadBinary(
-	{ binaryId, auth }: ParticleDownloadBinaryParams
+	{ binaryId, auth }: {
+		binaryId: string;
+		auth: string;
+	}
 ): Promise<string | undefined> {
 	info(`Downloading binary ${binaryId}`);
 	const resp = await particle.downloadFirmwareBinary({
@@ -78,7 +74,7 @@ export async function particleDownloadBinary(
 		const destName = 'firmware.bin';
 
 		const outputPath = `${destDir}/${destName}`;
-		if (!existsSync(destDir)){
+		if (!existsSync(destDir)) {
 			info(`Creating directory ${destDir}...`);
 			mkdirSync(destDir);
 		}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,10 @@
 import { _handleMultiFileArgs, populateFileMapping } from './cli';
-import { existsSync } from 'fs';
+import { existsSync, renameSync } from 'fs';
 // @ts-ignore
 import deviceConstants from '@particle/device-constants';
 import * as httpm from '@actions/http-client';
 import { maxSatisfying, major } from 'semver';
+import { dirname, join } from 'path';
 
 export function getCode(path: string) {
 	if (!existsSync(path)) {
@@ -112,6 +113,20 @@ export async function resolveVersion(platform: string, version: string): Promise
 		throw new Error(`No Device OS version satisfies '${version}'`);
 	}
 	return maxVersion;
+}
+
+export function renameFile({ filePath, platform, version }: {
+	filePath: string,
+	platform: string,
+	version: string
+}): string {
+	const dir = dirname(filePath);
+	const newFileName = `firmware-${platform}-${version}.bin`;
+	const newFilePath = join(dir, newFileName);
+
+	renameSync(filePath, newFilePath);
+
+	return newFilePath;
 }
 
 // For testing

--- a/src/versioning.test.ts
+++ b/src/versioning.test.ts
@@ -154,12 +154,12 @@ describe('incrementVersion', () => {
 			productVersionMacroName
 		});
 
-		expect(findProductVersionMacroFile).toHaveBeenCalledWith(sources, productVersionMacroName);
-		expect(currentFirmwareVersion).toHaveBeenCalledWith(
+		expect(findProductVersionMacroFile).toHaveBeenCalledWith({ sources, productVersionMacroName });
+		expect(currentFirmwareVersion).toHaveBeenCalledWith({
 			gitRepo,
 			versionFilePath,
 			productVersionMacroName
-		);
+		});
 		expect(readFile).toHaveBeenCalledWith(versionFilePath, 'utf-8');
 
 		const updatedFileContent = `${productVersionMacroName}(${nextVersion})`;
@@ -189,7 +189,7 @@ describe('isProductFirmware', () => {
 			productVersionMacroName
 		});
 
-		expect(findProductVersionMacroFile).toHaveBeenCalledWith(sources, productVersionMacroName);
+		expect(findProductVersionMacroFile).toHaveBeenCalledWith({ sources, productVersionMacroName });
 		expect(result).toBe(true);
 	});
 
@@ -205,7 +205,7 @@ describe('isProductFirmware', () => {
 			productVersionMacroName
 		});
 
-		expect(findProductVersionMacroFile).toHaveBeenCalledWith(sources, productVersionMacroName);
+		expect(findProductVersionMacroFile).toHaveBeenCalledWith({ sources, productVersionMacroName });
 		expect(result).toBe(false);
 	});
 
@@ -221,7 +221,7 @@ describe('isProductFirmware', () => {
 			productVersionMacroName
 		});
 
-		expect(findProductVersionMacroFile).toHaveBeenCalledWith(sources, productVersionMacroName);
+		expect(findProductVersionMacroFile).toHaveBeenCalledWith({ sources, productVersionMacroName });
 		expect(result).toBe(false);
 	});
 });

--- a/src/versioning.test.ts
+++ b/src/versioning.test.ts
@@ -1,0 +1,227 @@
+const findProductVersionMacroFileMock = jest.fn();
+const revisionOfLastVersionBumpMock = jest.fn();
+const currentFirmwareVersionMock = jest.fn();
+const mostRecentRevisionInFolderMock = jest.fn();
+
+jest.mock('./git', () => ({
+	findProductVersionMacroFile: findProductVersionMacroFileMock,
+	revisionOfLastVersionBump: revisionOfLastVersionBumpMock,
+	currentFirmwareVersion: currentFirmwareVersionMock,
+	mostRecentRevisionInFolder: mostRecentRevisionInFolderMock
+}));
+
+const readFileMock = jest.fn();
+const writeFileMock = jest.fn();
+jest.mock('fs/promises', () => ({
+	readFile: readFileMock,
+	writeFile: writeFileMock
+}));
+
+const warningMock = jest.fn();
+const infoMock = jest.fn();
+jest.mock('@actions/core', () => ({
+	warning: warningMock,
+	info: infoMock
+}));
+
+import { findProductVersionMacroFile, currentFirmwareVersion } from './git';
+import { readFile, writeFile } from 'fs/promises';
+import { isProductFirmware, incrementVersion } from './versioning';
+
+describe('shouldIncrementVersion', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	test('should return true if version increment is needed', async () => {
+		const gitRepo = '/path/to/repo';
+		const sources = '/path/to/sources';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+		const versionFilePath = '/path/to/version/file';
+
+		findProductVersionMacroFileMock.mockResolvedValue(versionFilePath);
+		revisionOfLastVersionBumpMock.mockResolvedValue('abcdef');
+		currentFirmwareVersionMock.mockResolvedValue(1);
+		mostRecentRevisionInFolderMock.mockResolvedValue('123456');
+
+		const { shouldIncrementVersion } = await import('./versioning');
+		const result = await shouldIncrementVersion({
+			gitRepo,
+			sources,
+			productVersionMacroName
+		});
+		expect(result).toBe(true);
+	});
+
+	test('should return false if version increment is not needed', async () => {
+		const gitRepo = '/path/to/repo';
+		const sources = '/path/to/sources';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+		const versionFilePath = '/path/to/version/file';
+
+		findProductVersionMacroFileMock.mockResolvedValue(versionFilePath);
+		revisionOfLastVersionBumpMock.mockResolvedValue('abcdef');
+		currentFirmwareVersionMock.mockResolvedValue(1);
+		mostRecentRevisionInFolderMock.mockResolvedValue('abcdef');
+
+		const { shouldIncrementVersion } = await import('./versioning');
+		const result = await shouldIncrementVersion({
+			gitRepo,
+			sources,
+			productVersionMacroName
+		});
+		expect(result).toBe(false);
+	});
+
+	test('should throw an error if version macro file is not found', async () => {
+		const gitRepo = '/path/to/repo';
+		const sources = '/path/to/sources';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+
+		findProductVersionMacroFileMock.mockResolvedValue(null);
+
+		const { shouldIncrementVersion } = await import('./versioning');
+		await expect(shouldIncrementVersion({
+			gitRepo,
+			sources,
+			productVersionMacroName
+		})).rejects.toThrow(
+			'Could not find a file containing the version macro.'
+		);
+	});
+
+	test('should throw an error if the last version increment is not found', async () => {
+		const gitRepo = '/path/to/repo';
+		const sources = '/path/to/sources';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+		const versionFilePath = '/path/to/version/file';
+
+		findProductVersionMacroFileMock.mockResolvedValue(versionFilePath);
+		revisionOfLastVersionBumpMock.mockResolvedValue(null);
+
+		const { shouldIncrementVersion } = await import('./versioning');
+		await expect(shouldIncrementVersion({
+			gitRepo,
+			sources,
+			productVersionMacroName
+		})).rejects.toThrow(
+			'Could not find the last version increment.'
+		);
+	});
+
+	test('should warn when the product version macro file has uncommitted changes', async () => {
+		const gitRepo = '/path/to/repo';
+		const sources = '/path/to/repo/sources';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+		const versionFilePath = '/path/to/repo/sources/version/file';
+
+		findProductVersionMacroFileMock.mockResolvedValue(versionFilePath);
+		revisionOfLastVersionBumpMock.mockResolvedValue('00000000');
+
+		const { shouldIncrementVersion } = await import('./versioning');
+		await shouldIncrementVersion({
+			gitRepo,
+			sources,
+			productVersionMacroName
+		});
+
+		expect(warningMock).toHaveBeenCalledWith('The file with the product version macro has uncommitted changes.');
+	});
+
+});
+
+describe('incrementVersion', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	test('should increment the version correctly', async () => {
+		const gitRepo = '/path/to/repo';
+		const sources = '/path/to/repo/src';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+		const versionFilePath = '/path/to/repo/src/file';
+		const currentVersion = 1;
+		const nextVersion = currentVersion + 1;
+		const fileContent = `${productVersionMacroName}(${currentVersion})`;
+
+		findProductVersionMacroFileMock.mockResolvedValue(versionFilePath);
+		currentFirmwareVersionMock.mockResolvedValue(currentVersion);
+		readFileMock.mockResolvedValue(fileContent);
+
+		const result = await incrementVersion({
+			gitRepo,
+			sources,
+			productVersionMacroName
+		});
+
+		expect(findProductVersionMacroFile).toHaveBeenCalledWith(sources, productVersionMacroName);
+		expect(currentFirmwareVersion).toHaveBeenCalledWith(
+			gitRepo,
+			versionFilePath,
+			productVersionMacroName
+		);
+		expect(readFile).toHaveBeenCalledWith(versionFilePath, 'utf-8');
+
+		const updatedFileContent = `${productVersionMacroName}(${nextVersion})`;
+		expect(writeFile).toHaveBeenCalledWith(versionFilePath, updatedFileContent);
+		expect(result).toEqual({
+			file: versionFilePath,
+			version: nextVersion
+		});
+	});
+});
+
+describe('isProductFirmware', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	test('should return true if product firmware is detected', async () => {
+		const sources = '/path/to/sources';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+		const versionFilePath = '/path/to/version/file';
+
+		// Set up the mock to return a version file path
+		findProductVersionMacroFileMock.mockResolvedValue(versionFilePath);
+
+		const result = await isProductFirmware({
+			sources,
+			productVersionMacroName
+		});
+
+		expect(findProductVersionMacroFile).toHaveBeenCalledWith(sources, productVersionMacroName);
+		expect(result).toBe(true);
+	});
+
+	test('should return false if product firmware is not detected', async () => {
+		const sources = '/path/to/sources';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+
+		// Set up the mock to return null (no version macro file found)
+		findProductVersionMacroFileMock.mockResolvedValue(null);
+
+		const result = await isProductFirmware({
+			sources,
+			productVersionMacroName
+		});
+
+		expect(findProductVersionMacroFile).toHaveBeenCalledWith(sources, productVersionMacroName);
+		expect(result).toBe(false);
+	});
+
+	test('should return false if an error occurs', async () => {
+		const sources = '/path/to/sources';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+
+		// Set up the mock to throw an error
+		findProductVersionMacroFileMock.mockRejectedValue(new Error('An error occurred'));
+
+		const result = await isProductFirmware({
+			sources,
+			productVersionMacroName
+		});
+
+		expect(findProductVersionMacroFile).toHaveBeenCalledWith(sources, productVersionMacroName);
+		expect(result).toBe(false);
+	});
+});

--- a/src/versioning.ts
+++ b/src/versioning.ts
@@ -9,23 +9,32 @@ import {
 	revisionOfLastVersionBump
 } from './git';
 
-interface ShouldIncrementVersionParams {
-	gitRepo: string;
-	sources: string;
-	productVersionMacroName: string;
-}
-
 export async function shouldIncrementVersion(
-	{ gitRepo, sources, productVersionMacroName }: ShouldIncrementVersionParams
+	{ gitRepo, sources, productVersionMacroName }: {
+		gitRepo: string;
+		sources: string;
+		productVersionMacroName: string;
+	}
 ): Promise<boolean> {
-	const versionFilePath = await findProductVersionMacroFile(sources, productVersionMacroName);
+	const versionFilePath = await findProductVersionMacroFile({
+		sources,
+		productVersionMacroName
+	});
 	if (!versionFilePath) {
 		throw new Error('Could not find a file containing the version macro.');
 	}
 
-	const lastChangeRevision = await revisionOfLastVersionBump(gitRepo, versionFilePath, productVersionMacroName);
-	const currentSourcesRevision = await mostRecentRevisionInFolder(gitRepo, sources);
-	const currentProductVersion = await currentFirmwareVersion(gitRepo, versionFilePath, productVersionMacroName);
+	const lastChangeRevision = await revisionOfLastVersionBump({
+		gitRepo: gitRepo,
+		versionFilePath: versionFilePath,
+		productVersionMacroName: productVersionMacroName
+	});
+	const currentSourcesRevision = await mostRecentRevisionInFolder({ gitRepo: gitRepo, folderPath: sources });
+	const currentProductVersion = await currentFirmwareVersion({
+		gitRepo: gitRepo,
+		versionFilePath: versionFilePath,
+		productVersionMacroName: productVersionMacroName
+	});
 
 	if (!lastChangeRevision) {
 		throw new Error('Could not find the last version increment.');
@@ -46,24 +55,24 @@ export async function shouldIncrementVersion(
 	return true;
 }
 
-interface IncrementVersionParams {
-	gitRepo: string;
-	sources: string;
-	productVersionMacroName: string;
-}
-
-export async function incrementVersion({ gitRepo, sources, productVersionMacroName }: IncrementVersionParams): Promise<{
+export async function incrementVersion(
+	{ gitRepo, sources, productVersionMacroName }: {
+		gitRepo: string;
+		sources: string;
+		productVersionMacroName: string;
+	}): Promise<{
 	file: string;
 	version: number
 }> {
 	// find the file containing the version macro
-	const versionFilePath = await findProductVersionMacroFile(sources, productVersionMacroName);
+	const versionFilePath = await findProductVersionMacroFile({
+		sources: sources,
+		productVersionMacroName: productVersionMacroName
+	});
 
 	// get the current version
 	const current = await currentFirmwareVersion(
-		gitRepo,
-		versionFilePath,
-		productVersionMacroName
+		{ gitRepo: gitRepo, versionFilePath: versionFilePath, productVersionMacroName: productVersionMacroName }
 	);
 
 	// increment the version
@@ -89,15 +98,18 @@ export async function incrementVersion({ gitRepo, sources, productVersionMacroNa
 	};
 }
 
-interface ProductFirmware {
-	sources: string;
-	productVersionMacroName: string;
-}
 
-export async function isProductFirmware({ sources, productVersionMacroName }: ProductFirmware): Promise<boolean> {
+export async function isProductFirmware(
+	{ sources, productVersionMacroName }: {
+		sources: string;
+		productVersionMacroName: string;
+	}): Promise<boolean> {
 	let isProductFirmware = false;
 	try {
-		isProductFirmware = !!await findProductVersionMacroFile(sources, productVersionMacroName);
+		isProductFirmware = !!await findProductVersionMacroFile({
+			sources: sources,
+			productVersionMacroName: productVersionMacroName
+		});
 	} catch (error) {
 		// Ignore
 	}

--- a/src/versioning.ts
+++ b/src/versioning.ts
@@ -1,0 +1,105 @@
+// Auto revision assumes the PRODUCT_VERSION macro is only incremented and not decremented.
+
+import { readFile, writeFile } from 'fs/promises';
+import { info, warning } from '@actions/core';
+import {
+	currentFirmwareVersion,
+	findProductVersionMacroFile,
+	mostRecentRevisionInFolder,
+	revisionOfLastVersionBump
+} from './git';
+
+interface ShouldIncrementVersionParams {
+	gitRepo: string;
+	sources: string;
+	productVersionMacroName: string;
+}
+
+export async function shouldIncrementVersion(
+	{ gitRepo, sources, productVersionMacroName }: ShouldIncrementVersionParams
+): Promise<boolean> {
+	const versionFilePath = await findProductVersionMacroFile(sources, productVersionMacroName);
+	if (!versionFilePath) {
+		throw new Error('Could not find a file containing the version macro.');
+	}
+
+	const lastChangeRevision = await revisionOfLastVersionBump(gitRepo, versionFilePath, productVersionMacroName);
+	const currentSourcesRevision = await mostRecentRevisionInFolder(gitRepo, sources);
+	const currentProductVersion = await currentFirmwareVersion(gitRepo, versionFilePath, productVersionMacroName);
+
+	if (!lastChangeRevision) {
+		throw new Error('Could not find the last version increment.');
+	}
+
+	info(`Current firmware version: ${currentProductVersion} (${currentSourcesRevision})`);
+	info(`Firmware version last set at: ${lastChangeRevision}`);
+	if (lastChangeRevision === '00000000') {
+		warning('The file with the product version macro has uncommitted changes.');
+	}
+
+	const shouldIncrement = currentSourcesRevision !== lastChangeRevision;
+	if (!shouldIncrement) {
+		info('No version increment detected. Skipping version increment.');
+		return false;
+	}
+	info(`Incrementing firmware version to ${currentProductVersion + 1}.`);
+	return true;
+}
+
+interface IncrementVersionParams {
+	gitRepo: string;
+	sources: string;
+	productVersionMacroName: string;
+}
+
+export async function incrementVersion({ gitRepo, sources, productVersionMacroName }: IncrementVersionParams): Promise<{
+	file: string;
+	version: number
+}> {
+	// find the file containing the version macro
+	const versionFilePath = await findProductVersionMacroFile(sources, productVersionMacroName);
+
+	// get the current version
+	const current = await currentFirmwareVersion(
+		gitRepo,
+		versionFilePath,
+		productVersionMacroName
+	);
+
+	// increment the version
+	const next = current + 1;
+
+	// find the line that matches this regex
+	const versionRegex = new RegExp(`^.*${productVersionMacroName}.*\\((\\d+)\\)`, 'gm');
+
+	// Read the file content
+	const fileContent = await readFile(versionFilePath, 'utf-8');
+
+	// Replace the version with the next version
+	const updatedFileContent = fileContent.replace(versionRegex, (match, p1) => {
+		info(`Replacing ${p1} with ${next} in ${versionFilePath}`);
+		return match.replace(p1, next.toString());
+	});
+
+	await writeFile(versionFilePath, updatedFileContent);
+
+	return {
+		file: versionFilePath,
+		version: next
+	};
+}
+
+interface ProductFirmware {
+	sources: string;
+	productVersionMacroName: string;
+}
+
+export async function isProductFirmware({ sources, productVersionMacroName }: ProductFirmware): Promise<boolean> {
+	let isProductFirmware = false;
+	try {
+		isProductFirmware = !!await findProductVersionMacroFile(sources, productVersionMacroName);
+	} catch (error) {
+		// Ignore
+	}
+	return isProductFirmware;
+}

--- a/test/fixtures/product-firmware/application.cpp
+++ b/test/fixtures/product-firmware/application.cpp
@@ -1,6 +1,6 @@
 #include "application.h"
 
-PRODUCT_VERSION(99);
+PRODUCT_VERSION(100);
 
 void setup() {}
 

--- a/test/fixtures/product-firmware/application.cpp
+++ b/test/fixtures/product-firmware/application.cpp
@@ -3,5 +3,4 @@
 PRODUCT_VERSION(100);
 
 void setup() {}
-
 void loop() {}

--- a/test/fixtures/product-firmware/application.cpp
+++ b/test/fixtures/product-firmware/application.cpp
@@ -1,0 +1,7 @@
+#include "application.h"
+
+PRODUCT_VERSION(99);
+
+void setup() {}
+
+void loop() {}


### PR DESCRIPTION
Story: https://app.shortcut.com/particle/story/117506

This PR adds an auto-versioning feature is designed to manage product firmware version numbers in an automated and consistent manner.

See `README.md` and `AUTO_VERSION.md` for usage documentation and example workflows.

There's a new CI test in [.github/workflows/test.yml](https://github.com/particle-iot/compile-action/compare/feature/auto-version?expand=1#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) that exercises the feature.