### PR TITLE
Add debug objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,5 +99,7 @@ __tests__/runner/*
 lib/**/*
 
 output
+target
+destination
 *.bin
 test/fixtures/tinker/tinker.cpp

--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -71,10 +71,14 @@ jobs:
         with:
           path: ${{ steps.compile.outputs.firmware-path }}
 
+      - name: Create archive of target directory
+        run: |
+          tar -czf debug-objects.tar.gz ${{ steps.compile.outputs.target-path }}
+
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: ${{ steps.compile.outputs.firmware-path }}
+          artifacts: ${{ steps.compile.outputs.firmware-path }},debug-objects.tar.gz
           generateReleaseNotes: 'true'
           name: "Firmware v${{ steps.compile.outputs.firmware-version }}"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -131,11 +135,16 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
 
+      - name: Create archive of target directory
+        if: steps.compile.outputs.firmware-version-updated == 'true'
+        run: |
+          tar -czf debug-objects.tar.gz ${{ steps.compile.outputs.target-path }}
+
       - name: Create GitHub release
         if: steps.compile.outputs.firmware-version-updated == 'true'
         uses: ncipollo/release-action@v1
         with:
-          artifacts: ${{ steps.compile.outputs.firmware-path }}
+          artifacts: ${{ steps.compile.outputs.firmware-path }},debug-objects.tar.gz
           generateReleaseNotes: 'true'
           name: "Firmware v${{ steps.compile.outputs.firmware-version }}"
           tag: "v${{ steps.compile.outputs.firmware-version }}"

--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -64,7 +64,6 @@ jobs:
         uses: particle-iot/compile-action@main
         with:
           particle-platform-name: 'boron'
-          device-os-version: 'latest-lts'
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -112,7 +111,6 @@ jobs:
         uses: particle-iot/compile-action@main
         with:
           particle-platform-name: 'boron'
-          device-os-version: 'latest-lts'
           auto-version: true
 
       - name: Upload artifacts

--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -68,7 +68,9 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ steps.compile.outputs.firmware-path }}
+          path: |
+            ${{ steps.compile.outputs.firmware-path }}
+            ${{ steps.compile.outputs.target-path }}
 
       - name: Create archive of target directory
         run: |
@@ -116,7 +118,9 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ steps.compile.outputs.firmware-path }}
+          path: |
+            ${{ steps.compile.outputs.firmware-path }}
+            ${{ steps.compile.outputs.target-path }}
 
       - name: Commit updated version file
         if: steps.compile.outputs.firmware-version-updated == 'true'

--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -69,12 +69,12 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ steps.compile.outputs.firmware-binary }}
+          path: ${{ steps.compile.outputs.firmware-path }}
 
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: ${{ steps.compile.outputs.firmware-binary }}
+          artifacts: ${{ steps.compile.outputs.firmware-path }}
           generateReleaseNotes: 'true'
           name: "Firmware v${{ steps.compile.outputs.firmware-version }}"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -114,7 +114,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ steps.compile.outputs.firmware-binary }}
+          path: ${{ steps.compile.outputs.firmware-path }}
 
       - name: Commit updated version file
         if: steps.compile.outputs.firmware-version-updated == 'true'
@@ -135,7 +135,7 @@ jobs:
         if: steps.compile.outputs.firmware-version-updated == 'true'
         uses: ncipollo/release-action@v1
         with:
-          artifacts: ${{ steps.compile.outputs.firmware-binary }}
+          artifacts: ${{ steps.compile.outputs.firmware-path }}
           generateReleaseNotes: 'true'
           name: "Firmware v${{ steps.compile.outputs.firmware-version }}"
           tag: "v${{ steps.compile.outputs.firmware-version }}"

--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -69,12 +69,12 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ steps.compile.outputs.artifact-path }}
+          path: ${{ steps.compile.outputs.firmware-binary }}
 
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: ${{ steps.compile.outputs.artifact-path }}
+          artifacts: ${{ steps.compile.outputs.firmware-binary }}
           generateReleaseNotes: 'true'
           name: "Firmware v${{ steps.compile.outputs.firmware-version }}"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -114,7 +114,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ steps.compile.outputs.artifact-path }}
+          path: ${{ steps.compile.outputs.firmware-binary }}
 
       - name: Commit updated version file
         if: steps.compile.outputs.firmware-version-updated == 'true'
@@ -135,7 +135,7 @@ jobs:
         if: steps.compile.outputs.firmware-version-updated == 'true'
         uses: ncipollo/release-action@v1
         with:
-          artifacts: ${{ steps.compile.outputs.artifact-path }}
+          artifacts: ${{ steps.compile.outputs.firmware-binary }}
           generateReleaseNotes: 'true'
           name: "Firmware v${{ steps.compile.outputs.firmware-version }}"
           tag: "v${{ steps.compile.outputs.firmware-version }}"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A GitHub Action to compile Particle application firmware
 
 ### Outputs
 
-* `firmware-binary`: Path to the compiled binary artifact. Example: `firmware-argon-2.3.1.bin`
+* `firmware-path`: Path to the compiled binary artifact. Example: `firmware-argon-2.3.1.bin`
 * `target-`
 * `device-os-version`: The Device OS version that was used for compilation. This may differ from the requested version if the requested version is a semver range or `latest` or `latest-lts`. Example: `2.3.1`
 * `firmware-version`: The product firmware version integer. This output is undefined when sources are not a product firmware.
@@ -80,7 +80,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: firmware
-          path: ${{ steps.compile.outputs.firmware-binary }}
+          path: ${{ steps.compile.outputs.firmware-path }}
 ```
 
 Compilation occurs inside the GitHub Action runner using the Particle [Buildpack Docker images](https://github.com/particle-iot/firmware-buildpack-builder).

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ A GitHub Action to compile Particle application firmware
 
 ### Outputs
 
-* `artifact-path`: Path to the compiled binary artifact. Example: `output/firmware-argon-2.3.1.bin`
+* `firmware-binary`: Path to the compiled binary artifact. Example: `firmware-argon-2.3.1.bin`
+* `target-`
 * `device-os-version`: The Device OS version that was used for compilation. This may differ from the requested version if the requested version is a semver range or `latest` or `latest-lts`. Example: `2.3.1`
 * `firmware-version`: The product firmware version integer. This output is undefined when sources are not a product firmware.
 * `firmware-version-updated`: Boolean value indicating whether the product firmware version was updated. Can only be true with auto-version enabled.
@@ -79,7 +80,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: firmware
-          path: ${{ steps.compile.outputs.artifact-path }}
+          path: ${{ steps.compile.outputs.firmware-binary }}
 ```
 
 Compilation occurs inside the GitHub Action runner using the Particle [Buildpack Docker images](https://github.com/particle-iot/firmware-buildpack-builder).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A GitHub Action to compile Particle application firmware
 ### Outputs
 
 * `firmware-path`: Path to the compiled binary artifact. Example: `firmware-argon-2.3.1.bin`
-* `target-`
+* `target-path`: Path to the folder with compiled firmware files and their associated object files. The folder includes the firmware binary, ELF, HEX, and MAP files, along with object files. Not available when particle-access-token is set (cloud compile).
 * `device-os-version`: The Device OS version that was used for compilation. This may differ from the requested version if the requested version is a semver range or `latest` or `latest-lts`. Example: `2.3.1`
 * `firmware-version`: The product firmware version integer. This output is undefined when sources are not a product firmware.
 * `firmware-version-updated`: Boolean value indicating whether the product firmware version was updated. Can only be true with auto-version enabled.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: firmware
-          path: ${{ steps.compile.outputs.firmware-path }}
+          path: |
+            ${{ steps.compile.outputs.firmware-path }}
+            ${{ steps.compile.outputs.target-path }}
 ```
 
 Compilation occurs inside the GitHub Action runner using the Particle [Buildpack Docker images](https://github.com/particle-iot/firmware-buildpack-builder).

--- a/action.yml
+++ b/action.yml
@@ -26,10 +26,12 @@ inputs:
     description: 'Name of the macro that contains the product firmware version.'
     default: 'PRODUCT_VERSION'
 outputs:
-  artifact-path:
-    description: 'Path to the compiled binary file. Example: output/firmware-argon-2.3.1.bin'
+  firmware-binary:
+    description: 'Path to the compiled firmware binary file.'
+  target-directory:
+    description: 'Path to the folder with compiled firmware files and their associated object files. The folder includes the firmware binary, ELF, HEX, and MAP files, along with object files. Only available when compiling locally.'
   device-os-version:
-    description: 'This output contains the actual Device OS version used for compilation. Example: 4.0.2'
+    description: 'This output contains the actual Device OS version used for compilation.'
   firmware-version:
     description: 'The product firmware version integer. This output is undefined when sources are not a product firmware.'
   firmware-version-updated:

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
 outputs:
   firmware-path:
     description: 'Path to the compiled firmware binary file.'
-  target-directory:
+  target-path:
     description: 'Path to the folder with compiled firmware files and their associated object files. The folder includes the firmware binary, ELF, HEX, and MAP files, along with object files. Not available when particle-access-token is set (cloud compile).'
   device-os-version:
     description: 'This output contains the actual Device OS version used for compilation.'

--- a/action.yml
+++ b/action.yml
@@ -26,10 +26,10 @@ inputs:
     description: 'Name of the macro that contains the product firmware version.'
     default: 'PRODUCT_VERSION'
 outputs:
-  firmware-binary:
+  firmware-path:
     description: 'Path to the compiled firmware binary file.'
   target-directory:
-    description: 'Path to the folder with compiled firmware files and their associated object files. The folder includes the firmware binary, ELF, HEX, and MAP files, along with object files. Only available when compiling locally.'
+    description: 'Path to the folder with compiled firmware files and their associated object files. The folder includes the firmware binary, ELF, HEX, and MAP files, along with object files. Not available when particle-access-token is set (cloud compile).'
   device-os-version:
     description: 'This output contains the actual Device OS version used for compilation.'
   firmware-version:

--- a/dist/index.js
+++ b/dist/index.js
@@ -33938,7 +33938,7 @@ function resolveInputs() {
     });
 }
 function setOutputs({ firmwareBinary, targetDir, deviceOsVersion, firmwareVersion, firmwareVersionUpdated }) {
-    (0, core_1.setOutput)('firmware-binary', firmwareBinary);
+    (0, core_1.setOutput)('firmware-path', firmwareBinary);
     (0, core_1.setOutput)('target-directory', targetDir);
     (0, core_1.setOutput)('device-os-version', deviceOsVersion);
     (0, core_1.setOutput)('firmware-version', firmwareVersion);

--- a/dist/index.js
+++ b/dist/index.js
@@ -33939,7 +33939,7 @@ function resolveInputs() {
 }
 function setOutputs({ firmwareBinary, targetDir, deviceOsVersion, firmwareVersion, firmwareVersionUpdated }) {
     (0, core_1.setOutput)('firmware-path', firmwareBinary);
-    (0, core_1.setOutput)('target-directory', targetDir);
+    (0, core_1.setOutput)('target-path', targetDir);
     (0, core_1.setOutput)('device-os-version', deviceOsVersion);
     (0, core_1.setOutput)('firmware-version', firmwareVersion);
     (0, core_1.setOutput)('firmware-version-updated', firmwareVersionUpdated);

--- a/dist/index.js
+++ b/dist/index.js
@@ -33937,8 +33937,9 @@ function resolveInputs() {
         return { auth, platform, sources, autoVersionEnabled, versionMacroName, targetVersion };
     });
 }
-function setOutputs({ artifactPath, deviceOsVersion, firmwareVersion, firmwareVersionUpdated }) {
-    (0, core_1.setOutput)('artifact-path', artifactPath);
+function setOutputs({ firmwareBinary, targetDir, deviceOsVersion, firmwareVersion, firmwareVersionUpdated }) {
+    (0, core_1.setOutput)('firmware-binary', firmwareBinary);
+    (0, core_1.setOutput)('target-directory', targetDir);
     (0, core_1.setOutput)('device-os-version', deviceOsVersion);
     (0, core_1.setOutput)('firmware-version', firmwareVersion);
     (0, core_1.setOutput)('firmware-version-updated', firmwareVersionUpdated);
@@ -34007,13 +34008,19 @@ exports.autoVersion = autoVersion;
 function compile({ auth, platform, sources, targetVersion }) {
     return __awaiter(this, void 0, void 0, function* () {
         let outputPath;
+        let targetDir = '';
         if (!auth) {
             (0, core_1.info)('No access token provided, running local compilation');
             yield (0, docker_1.dockerCheck)();
             // Preprocesses .ino files into .cpp files
             // The cloud compiler does this automatically
             (0, util_1.preprocessSources)(sources);
-            outputPath = yield (0, docker_1.dockerBuildpackCompile)({ sources, platform, targetVersion, workingDir: process.cwd() });
+            const containerName = `compile-${Date.now()}`;
+            outputPath = yield (0, docker_1.dockerBuildpackCompile)({
+                sources, platform, targetVersion, workingDir: process.cwd(), containerName
+            });
+            targetDir = 'target';
+            yield (0, docker_1.downloadTargetDirectory)({ containerName: containerName, destination: targetDir });
         }
         else {
             (0, core_1.info)('Access token provided, running cloud compilation');
@@ -34021,9 +34028,9 @@ function compile({ auth, platform, sources, targetVersion }) {
             if (!binaryId) {
                 throw new Error('Failed to compile code in cloud');
             }
-            outputPath = yield (0, particle_api_1.particleDownloadBinary)({ binaryId, auth });
+            outputPath = yield (0, particle_api_1.particleDownloadBinary)({ binaryId, auth, platform, targetVersion });
         }
-        return { outputPath };
+        return { outputPath, targetDir };
     });
 }
 exports.compile = compile;
@@ -34035,7 +34042,7 @@ function compileAction() {
             const { version, incremented } = yield autoVersion({
                 sources, gitRepo, autoVersionEnabled, versionMacroName
             });
-            const { outputPath } = yield compile({ auth, platform, sources, targetVersion });
+            const { outputPath, targetDir } = yield compile({ auth, platform, sources, targetVersion });
             if (outputPath) {
                 const artifactPath = (0, util_1.renameFile)({
                     filePath: outputPath,
@@ -34043,7 +34050,8 @@ function compileAction() {
                     version: targetVersion
                 });
                 setOutputs({
-                    artifactPath: artifactPath,
+                    firmwareBinary: artifactPath,
+                    targetDir,
                     deviceOsVersion: targetVersion,
                     firmwareVersion: version,
                     firmwareVersionUpdated: incremented
@@ -34189,7 +34197,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.dockerBuildpackCompile = exports.dockerCheck = void 0;
+exports.downloadTargetDirectory = exports.dockerBuildpackCompile = exports.dockerCheck = void 0;
 const core_1 = __nccwpck_require__(2186);
 const fs_1 = __nccwpck_require__(7147);
 const execa_1 = __importDefault(__nccwpck_require__(5447));
@@ -34210,7 +34218,7 @@ function dockerCheck() {
     });
 }
 exports.dockerCheck = dockerCheck;
-function dockerBuildpackCompile({ workingDir, sources, platform, targetVersion }) {
+function dockerBuildpackCompile({ workingDir, sources, platform, targetVersion, containerName }) {
     return __awaiter(this, void 0, void 0, function* () {
         // Note: the buildpack only detects *.c and *.cpp files
         // https://github.com/particle-iot/device-os/blob/196d497dd4c16ab83db6ea610cf2433047226a6a/user/build.mk#L64-L65
@@ -34235,7 +34243,7 @@ function dockerBuildpackCompile({ workingDir, sources, platform, targetVersion }
         const platformId = (0, util_1.getPlatformId)(platform);
         const args = [
             'run',
-            '--rm',
+            `--name=${containerName}`,
             '-v',
             `${inputDir}:/input`,
             '-v',
@@ -34246,10 +34254,25 @@ function dockerBuildpackCompile({ workingDir, sources, platform, targetVersion }
         ];
         const dockerRun = yield (0, execa_1.default)('docker', args);
         (0, core_1.info)(dockerRun.stdout);
-        return outputPath;
+        // move output/firmware.bin to firmware-<platform>-<version>.bin
+        const destPath = `firmware-${platform}-${targetVersion}.bin`;
+        yield (0, execa_1.default)('mv', [outputPath, destPath]);
+        return destPath;
     });
 }
 exports.dockerBuildpackCompile = dockerBuildpackCompile;
+function downloadTargetDirectory({ containerName, destination }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Download the /workspace/target folder from the container
+        const args = [
+            'cp',
+            `${containerName}:/workspace/target`,
+            destination
+        ];
+        yield (0, execa_1.default)('docker', args);
+    });
+}
+exports.downloadTargetDirectory = downloadTargetDirectory;
 
 
 /***/ }),
@@ -34467,7 +34490,7 @@ function particleCloudCompile({ sources, platform, auth, targetVersion }) {
     });
 }
 exports.particleCloudCompile = particleCloudCompile;
-function particleDownloadBinary({ binaryId, auth }) {
+function particleDownloadBinary({ binaryId, auth, platform, targetVersion }) {
     return __awaiter(this, void 0, void 0, function* () {
         (0, core_1.info)(`Downloading binary ${binaryId}`);
         const resp = yield particle.downloadFirmwareBinary({
@@ -34477,13 +34500,8 @@ function particleDownloadBinary({ binaryId, auth }) {
         });
         if (resp instanceof Buffer) {
             (0, core_1.info)(`Binary downloaded successfully.`);
-            const destDir = 'output';
-            const destName = 'firmware.bin';
-            const outputPath = `${destDir}/${destName}`;
-            if (!(0, fs_1.existsSync)(destDir)) {
-                (0, core_1.info)(`Creating directory ${destDir}...`);
-                (0, fs_1.mkdirSync)(destDir);
-            }
+            const destName = `firmware-${platform}-${targetVersion}.bin`;
+            const outputPath = `${destName}`;
             (0, fs_1.writeFileSync)(`${outputPath}`, resp, 'utf8');
             (0, core_1.info)(`File downloaded successfully.`);
             return outputPath;

--- a/src/action.ts
+++ b/src/action.ts
@@ -43,7 +43,7 @@ function setOutputs(
 	{ firmwareBinary, targetDir, deviceOsVersion, firmwareVersion, firmwareVersionUpdated }: ActionOutputs
 ): void {
 	setOutput('firmware-path', firmwareBinary);
-	setOutput('target-directory', targetDir);
+	setOutput('target-path', targetDir);
 	setOutput('device-os-version', deviceOsVersion);
 	setOutput('firmware-version', firmwareVersion);
 	setOutput('firmware-version-updated', firmwareVersionUpdated);

--- a/src/action.ts
+++ b/src/action.ts
@@ -42,7 +42,7 @@ async function resolveInputs(): Promise<ActionInputs> {
 function setOutputs(
 	{ firmwareBinary, targetDir, deviceOsVersion, firmwareVersion, firmwareVersionUpdated }: ActionOutputs
 ): void {
-	setOutput('firmware-binary', firmwareBinary);
+	setOutput('firmware-path', firmwareBinary);
 	setOutput('target-directory', targetDir);
 	setOutput('device-os-version', deviceOsVersion);
 	setOutput('firmware-version', firmwareVersion);

--- a/src/particle-api.test.ts
+++ b/src/particle-api.test.ts
@@ -1,7 +1,7 @@
 import { sep } from 'node:path';
 import { mkdtemp } from 'node:fs';
 import { tmpdir } from 'os';
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, unlinkSync, writeFileSync } from 'fs';
 import nock from 'nock';
 
 // Need to be before imports
@@ -287,15 +287,21 @@ describe('particleCloudCompile', () => {
 describe('particleCloudDownload', () => {
 
 	it('should return a file sources on a successful download', async () => {
-		const path = await particleDownloadBinary({ binaryId: '1234', auth: 'token' });
+		const path = await particleDownloadBinary({
+			binaryId: '1234', auth: 'token', targetVersion: '1.4.4', platform: 'core'
+
+		});
 		expect(mockDownloadFirmwareBinary).toHaveBeenCalledTimes(1);
 		expect(mockDownloadFirmwareBinary).toHaveBeenCalledWith({
 			'binaryId': '1234',
 			'auth': 'token',
 			'headers': { 'User-Agent': 'particle-compile-action' }
 		});
-		expect(path).toEqual('output/firmware.bin');
+		expect(path).toEqual('firmware-core-1.4.4.bin');
 		expect(readFileSync(path || '').toString()).toEqual('test');
+
+		// remove test file firmware-core-1.4.4.bin
+		unlinkSync('firmware-core-1.4.4.bin');
 	});
 });
 

--- a/src/particle-api.ts
+++ b/src/particle-api.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line max-len
 import { error, info } from '@actions/core';
-import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { writeFileSync } from 'fs';
 import { getCode, getPlatformId } from './util';
 
 const ParticleApi = require('particle-api-js');
@@ -57,9 +57,11 @@ export async function particleCloudCompile(
 }
 
 export async function particleDownloadBinary(
-	{ binaryId, auth }: {
+	{ binaryId, auth, platform, targetVersion }: {
 		binaryId: string;
 		auth: string;
+		platform: string;
+		targetVersion: string;
 	}
 ): Promise<string | undefined> {
 	info(`Downloading binary ${binaryId}`);
@@ -70,16 +72,9 @@ export async function particleDownloadBinary(
 	});
 	if (resp instanceof Buffer) {
 		info(`Binary downloaded successfully.`);
-		const destDir = 'output';
-		const destName = 'firmware.bin';
-
-		const outputPath = `${destDir}/${destName}`;
-		if (!existsSync(destDir)) {
-			info(`Creating directory ${destDir}...`);
-			mkdirSync(destDir);
-		}
+		const destName = `firmware-${platform}-${targetVersion}.bin`;
+		const outputPath = `${destName}`;
 		writeFileSync(`${outputPath}`, resp, 'utf8');
-
 		info(`File downloaded successfully.`);
 		return outputPath;
 	}


### PR DESCRIPTION
Story: https://app.shortcut.com/particle/story/118223/

This PR:
* aligns firmware binary output name with other Actions (`artifact-path` => `firmware-path`)
* adds new output that points to the target directory with debug assets from the compile (`target-path`)
* updates examples/docs to use the updated outputs


## How to test
Run a local compile via `env "INPUT_SOURCES-FOLDER=test/fixtures/single-file-firmware" env "INPUT_PARTICLE-PLATFORM-NAME=argon" env "INPUT_DEVICE-OS-VERSION=default" npm start` (see [dev docs](https://github.com/particle-iot/compile-action/blob/main/DEVELOPMENT.md))

* There should be a new `target` directory with the elf, lst, hex, and map files in the folder you ran the command
* you should see `::set-output name=target-path::target` in the stdout/logs from the Action run
