### PR TITLE
Use the same output streams as the parent process

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34226,7 +34226,7 @@ function dockerBuildpackCompile({ workingDir, sources, platform, targetVersion, 
         const dockerPull = yield (0, execa_1.default)('docker', [
             'pull',
             `particle/buildpack-particle-firmware:${targetVersion}-${platform}`
-        ]);
+        ], { stdio: 'inherit' });
         (0, core_1.info)(dockerPull.stdout);
         const destDir = 'output';
         const destName = 'firmware.bin';
@@ -34252,7 +34252,7 @@ function dockerBuildpackCompile({ workingDir, sources, platform, targetVersion, 
             `PLATFORM_ID=${platformId}`,
             `particle/buildpack-particle-firmware:${targetVersion}-${platform}`
         ];
-        const dockerRun = yield (0, execa_1.default)('docker', args);
+        const dockerRun = yield (0, execa_1.default)('docker', args, { stdio: 'inherit' });
         (0, core_1.info)(dockerRun.stdout);
         // move output/firmware.bin to firmware-<platform>-<version>.bin
         const destPath = `firmware-${platform}-${targetVersion}.bin`;

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -87,7 +87,8 @@ describe('dockerBuildpackCompile', () => {
 			[
 				'pull',
 				'particle/buildpack-particle-firmware:4.0.2-argon'
-			]
+			],
+			{ 'stdio': 'inherit' }
 		]);
 		expect(execa.mock.calls[1]).toEqual([
 			'docker',
@@ -101,7 +102,8 @@ describe('dockerBuildpackCompile', () => {
 				'-e',
 				'PLATFORM_ID=12',
 				'particle/buildpack-particle-firmware:4.0.2-argon'
-			]]);
+			],
+			{ 'stdio': 'inherit' }]);
 		expect(execa.mock.calls[2]).toEqual([
 			'mv',
 			[
@@ -133,7 +135,9 @@ describe('dockerBuildpackCompile', () => {
 				'-e',
 				'PLATFORM_ID=12',
 				'particle/buildpack-particle-firmware:4.0.2-argon'
-			]]);
+			],
+			{ 'stdio': 'inherit' }
+		]);
 		expect(execa.mock.calls[2]).toEqual([
 			'mv',
 			[
@@ -167,7 +171,9 @@ describe('dockerBuildpackCompile', () => {
 				'-e',
 				'PLATFORM_ID=12',
 				'particle/buildpack-particle-firmware:4.0.2-argon'
-			]]);
+			],
+			{ 'stdio': 'inherit' }
+		]);
 		expect(execa.mock.calls[2]).toEqual([
 			'mv',
 			[
@@ -199,7 +205,9 @@ describe('dockerBuildpackCompile', () => {
 				'-e',
 				'PLATFORM_ID=12',
 				'particle/buildpack-particle-firmware:4.0.2-argon'
-			]]);
+			],
+			{ 'stdio': 'inherit' }
+		]);
 		expect(execa.mock.calls[2]).toEqual([
 			'mv',
 			[

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -32,7 +32,7 @@ export async function dockerBuildpackCompile(
 	const dockerPull = await execa('docker', [
 		'pull',
 		`particle/buildpack-particle-firmware:${targetVersion}-${platform}`
-	]);
+	], { stdio: 'inherit' });
 	info(dockerPull.stdout);
 
 	const destDir = 'output';
@@ -60,7 +60,7 @@ export async function dockerBuildpackCompile(
 		`PLATFORM_ID=${platformId}`,
 		`particle/buildpack-particle-firmware:${targetVersion}-${platform}`
 	];
-	const dockerRun = await execa('docker', args);
+	const dockerRun = await execa('docker', args, { stdio: 'inherit' });
 	info(dockerRun.stdout);
 
 	// move output/firmware.bin to firmware-<platform>-<version>.bin


### PR DESCRIPTION
Produces better log experience by streaming logs when the happen rather than buffering them up and dumping the whole buffer at the end.

No local testing steps. If interested, rerunning a [CI job](https://github.com/particle-iot/compile-action/actions/runs/4994584465/jobs/8945372301?pr=19) should succeed and produce a normal stream of log messages.