### PR TITLE
fix: [sc-125817] Fix auto-version crash for deleted files

### DIFF
--- a/AUTO_VERSION.md
+++ b/AUTO_VERSION.md
@@ -4,6 +4,9 @@
 
 The auto-versioning feature is designed to manage product firmware version numbers in an automated and consistent manner.
 
+It is primarily intended for use in Action workflows that release firmware and upload it to Particle products.
+Here is an [example firmware project](https://github.com/particle-iot/firmware-cicd-examples/tree/main/product-firmware) that has a two GitHub Actions workflows: build and upload.
+
 ## Usage
 
 Auto-versioning is disabled by default. To enable auto-versioning:
@@ -188,3 +191,8 @@ jobs:
 1. Manual Version Changes: If you manually increment the version macro while automatic versioning is enabled, the automatic versioning system may increment the version again.
    It is recommended that you disable automatic versioning if you are going to manually increment the version macro.
 
+
+## Debugging
+
+To debug the auto-versioning feature, you can [re-run a job with debug logging](https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/) enabled.
+This will allow you to see the step-by-step process of how the version number is determined and incremented. 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Other Actions for firmware development: Compile | [Flash Device](https://github.
     # Required: true
     particle-platform-name: ''
       
-    # Path to directory with sources to compile
+    # This is your Particle project directory
+    # It contains your source code, libraries, and the project.properties file
     # Required: false
     sources-folder: '.'
       

--- a/src/autoversion.test.ts
+++ b/src/autoversion.test.ts
@@ -19,9 +19,13 @@ jest.mock('fs/promises', () => ({
 
 const warningMock = jest.fn();
 const infoMock = jest.fn();
+const debugMock = jest.fn();
+const errorMock = jest.fn();
 jest.mock('@actions/core', () => ({
 	warning: warningMock,
-	info: infoMock
+	info: infoMock,
+	debug: debugMock,
+	error: errorMock
 }));
 
 import { findProductVersionMacroFile, currentFirmwareVersion } from './git';

--- a/src/autoversion.ts
+++ b/src/autoversion.ts
@@ -1,13 +1,52 @@
-// Auto revision assumes the PRODUCT_VERSION macro is only incremented and not decremented.
-
 import { readFile, writeFile } from 'fs/promises';
-import { info, warning } from '@actions/core';
+import { info, warning, debug, error } from '@actions/core';
+import simpleGit, { SimpleGit } from 'simple-git';
 import {
 	currentFirmwareVersion,
 	findProductVersionMacroFile,
 	mostRecentRevisionInFolder,
 	revisionOfLastVersionBump
 } from './git';
+
+const git: SimpleGit = simpleGit();
+
+// Detailed Git repo state logging functions, for debugging git state in the Action runner
+async function logGitStatus(gitRepo: string): Promise<void> {
+	try {
+		const status = await git.cwd(gitRepo).status();
+		debug(`Git Status: ${JSON.stringify(status)}`);
+	} catch (e) {
+		error(`Error getting Git status: ${e}`);
+	}
+}
+
+async function logGitBranches(gitRepo: string): Promise<void> {
+	try {
+		const branches = await git.cwd(gitRepo).branchLocal();
+		debug(`Local branches: ${JSON.stringify(branches)}`);
+	} catch (e) {
+		error(`Error listing branches: ${e}`);
+	}
+}
+
+async function logGitCommitHistory(gitRepo: string, filePath: string): Promise<void> {
+	try {
+		const log = await git.cwd(gitRepo).log({ file: filePath });
+		debug(`Git log for ${filePath}: ${JSON.stringify(log)}`);
+	} catch (e) {
+		error(`Error getting Git log for file ${filePath}: ${e}`);
+	}
+}
+
+async function getChangedFilesBetweenCommits(gitRepo: string, commit1: string, commit2: string): Promise<string[]> {
+	try {
+		const diffSummary = await git.cwd(gitRepo).diffSummary([commit1, commit2]);
+		return diffSummary.files.map(file => file.file);
+	} catch (e) {
+		error(`Error getting changed files between commits ${commit1} and ${commit2}: ${e}`);
+		return [];
+	}
+}
 
 export async function shouldIncrementVersion(
 	{ gitRepo, sources, productVersionMacroName }: {
@@ -16,6 +55,12 @@ export async function shouldIncrementVersion(
 		productVersionMacroName: string;
 	}
 ): Promise<boolean> {
+	debug(`Starting shouldIncrementVersion for productVersionMacroName: ${productVersionMacroName} in repo: ${gitRepo}`);
+
+	// Additional debugging around Git repo state at the start
+	await logGitStatus(gitRepo);
+	await logGitBranches(gitRepo);
+
 	const versionFilePath = await findProductVersionMacroFile({
 		sources,
 		productVersionMacroName
@@ -24,17 +69,31 @@ export async function shouldIncrementVersion(
 		throw new Error('Could not find a file containing the version macro.');
 	}
 
+	debug(`Version file path found: ${versionFilePath}`);
+	await logGitCommitHistory(gitRepo, versionFilePath);
+
 	const lastChangeRevision = await revisionOfLastVersionBump({
 		gitRepo: gitRepo,
 		versionFilePath: versionFilePath,
 		productVersionMacroName: productVersionMacroName
 	});
+	debug(`Last change revision: ${lastChangeRevision}`);
+
 	const currentSourcesRevision = await mostRecentRevisionInFolder({ gitRepo: gitRepo, folderPath: sources });
+	debug(`Current sources revision: ${currentSourcesRevision}`);
+
+	// Additional debugging around changed files
+	if (lastChangeRevision !== currentSourcesRevision) {
+		const changedFiles = await getChangedFilesBetweenCommits(gitRepo, lastChangeRevision, currentSourcesRevision);
+		debug(`Files changed between ${lastChangeRevision} and ${currentSourcesRevision}: ${JSON.stringify(changedFiles)}`);
+	}
+
 	const currentProductVersion = await currentFirmwareVersion({
 		gitRepo: gitRepo,
 		versionFilePath: versionFilePath,
 		productVersionMacroName: productVersionMacroName
 	});
+	debug(`Current product version: ${currentProductVersion}`);
 
 	if (!lastChangeRevision) {
 		throw new Error('Could not find the last version increment.');
@@ -42,15 +101,19 @@ export async function shouldIncrementVersion(
 
 	info(`Current firmware version: ${currentProductVersion} (${currentSourcesRevision})`);
 	info(`Firmware version last set at: ${lastChangeRevision}`);
+
 	if (lastChangeRevision === '00000000') {
 		warning('The file with the product version macro has uncommitted changes.');
 	}
 
 	const shouldIncrement = currentSourcesRevision !== lastChangeRevision;
+	debug(`Should increment version: ${shouldIncrement}`);
+
 	if (!shouldIncrement) {
 		info('No version increment detected. Skipping version increment.');
 		return false;
 	}
+
 	info(`Incrementing firmware version to ${currentProductVersion + 1}.`);
 	return true;
 }
@@ -64,33 +127,42 @@ export async function incrementVersion(
 	file: string;
 	version: number
 }> {
-	// find the file containing the version macro
+	debug(`Starting incrementVersion for productVersionMacroName: ${productVersionMacroName} in repo: ${gitRepo}`);
+
 	const versionFilePath = await findProductVersionMacroFile({
-		sources: sources,
+		sources,
+		productVersionMacroName
+	});
+
+	debug(`Version file path for incrementing: ${versionFilePath}`);
+
+	const current = await currentFirmwareVersion({
+		gitRepo: gitRepo,
+		versionFilePath: versionFilePath,
 		productVersionMacroName: productVersionMacroName
 	});
 
-	// get the current version
-	const current = await currentFirmwareVersion(
-		{ gitRepo: gitRepo, versionFilePath: versionFilePath, productVersionMacroName: productVersionMacroName }
-	);
-
-	// increment the version
+	debug(`Current version before increment: ${current}`);
 	const next = current + 1;
 
-	// find the line that matches this regex
 	const versionRegex = new RegExp(`^.*${productVersionMacroName}.*\\((\\d+)\\)`, 'gm');
 
-	// Read the file content
 	const fileContent = await readFile(versionFilePath, 'utf-8');
+	debug(`Read version file content from: ${versionFilePath}`);
 
-	// Replace the version with the next version
 	const updatedFileContent = fileContent.replace(versionRegex, (match, p1) => {
 		info(`Replacing ${p1} with ${next} in ${versionFilePath}`);
+		debug(`Match found for version increment: ${match}`);
 		return match.replace(p1, next.toString());
 	});
 
 	await writeFile(versionFilePath, updatedFileContent);
+	debug(`Version file updated: ${versionFilePath}`);
+
+	// Additional debugging around Git repo state at the end
+	// A successful version increment should leave a modified file in the repo
+	// Users should commit and push the updated version file to git after `compile-action` finishes
+	await logGitStatus(gitRepo);
 
 	return {
 		file: versionFilePath,
@@ -98,19 +170,22 @@ export async function incrementVersion(
 	};
 }
 
-
 export async function isProductFirmware(
 	{ sources, productVersionMacroName }: {
 		sources: string;
 		productVersionMacroName: string;
 	}): Promise<boolean> {
+	debug(`Checking if product firmware for productVersionMacroName: ${productVersionMacroName}`);
+
 	let isProductFirmware = false;
 	try {
 		isProductFirmware = !!await findProductVersionMacroFile({
 			sources: sources,
 			productVersionMacroName: productVersionMacroName
 		});
-	} catch (error) {
+		debug(`Product firmware status: ${isProductFirmware}`);
+	} catch (err) {
+		debug(`Error in isProductFirmware: ${err}`);
 		// Ignore
 	}
 	return isProductFirmware;

--- a/src/autoversion.ts
+++ b/src/autoversion.ts
@@ -69,7 +69,6 @@ export async function shouldIncrementVersion(
 		throw new Error('Could not find a file containing the version macro.');
 	}
 
-	debug(`Version file path found: ${versionFilePath}`);
 	await logGitCommitHistory(gitRepo, versionFilePath);
 
 	const lastChangeRevision = await revisionOfLastVersionBump({

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -167,6 +167,26 @@ describe('currentFirmwareVersion', () => {
 
 		expect(result).toBe(0);
 	});
+
+	test('should handle when the version file was deleted in a previous commit', async () => {
+		const commitHashes = ['a1b2c3d4e5f6', 'b2c3d4e5f6a1'];
+		const gitRepo = '/path/to/repo';
+		const versionFilePath = '/path/to/repo/project-folder/application.cpp';
+		const productVersionMacroName = 'PRODUCT_VERSION';
+
+		logMock.mockResolvedValue(createLogMock(commitHashes));
+		showMock
+			.mockRejectedValueOnce(new Error(`path '${versionFilePath}' exists on disk, but not in '${commitHashes[0]}'`))
+			.mockResolvedValueOnce(createCommitBodyMock(productVersionMacroName, 1));
+
+		const result = await currentFirmwareVersion({
+			gitRepo: gitRepo,
+			versionFilePath: versionFilePath,
+			productVersionMacroName: productVersionMacroName
+		});
+
+		expect(result).toBe(1);
+	});
 });
 
 describe('findProductVersionMacroFile', () => {

--- a/src/git.ts
+++ b/src/git.ts
@@ -27,10 +27,15 @@ export async function currentFirmwareVersion(
 
 	for (const log of logs.all) {
 		const currentCommit = log.hash;
-		const commitBody = await git.show([`${currentCommit}:${versionFilePath}`]);
 
 		// Use regex to extract the PRODUCT_VERSION from the patch
 		const versionRegex = new RegExp(`^.*${productVersionMacroName}.*\\((\\d+)\\)`, 'gm');
+		let commitBody = '';
+		try {
+			commitBody = await git.show([`${currentCommit}:${versionFilePath}`]);
+		} catch (error) {
+			debug(`Error getting the file ${versionFilePath} from commit ${currentCommit}: ${error}. This can occur if the file was deleted in the commit. Skipping commit`);
+		}
 
 		const match = versionRegex.exec(commitBody);
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/125817

It fixes errors like `Error: path '/path/to/repo/project-folder/application.cpp' exists on disk but not in 'a1b2c3d4e5f6'.`

The bug fix is https://github.com/particle-iot/compile-action/pull/27/commits/41081c4419cc3f84e76f36c325ab737db086997c, and most of the other changes add new debug-level log messages that can help troubleshoot issues with the auto-version feature. Users can [toggle on](https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/) the debug logs.